### PR TITLE
641: Handling InvalidJwtExceptions raised by JwtReconstruction

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -49,7 +49,13 @@ switch(method.toUpperCase()) {
 
         // Parse incoming registration JWT
         logger.debug(SCRIPT_NAME + "Parsing registration request");
-        def regJwt = new JwtReconstruction().reconstructJwt(request.entity.getString(),SignedJwt.class)
+        def regJwt
+        try {
+            regJwt = new JwtReconstruction().reconstructJwt(request.entity.getString(), SignedJwt.class)
+        } catch (e) {
+            logger.warn(SCRIPT_NAME + "failed to decode registration request JWT", e)
+            return errorResponseFactory.invalidClientMetadataErrorResponse("registration request object is not a valid JWT")
+        }
 
         // Pull the SSA from the reg data
 
@@ -75,7 +81,13 @@ switch(method.toUpperCase()) {
         logger.debug(SCRIPT_NAME + "Got ssa [" + ssa + "]")
         oidcRegistration.setClaim("software_statement", null);
 
-        def ssaJwt = new JwtReconstruction().reconstructJwt(ssa,SignedJwt.class)
+        def ssaJwt
+        try {
+            ssaJwt = new JwtReconstruction().reconstructJwt(ssa, SignedJwt.class)
+        } catch (e) {
+            logger.warn(SCRIPT_NAME + "failed to decode software_statement JWT", e)
+            return errorResponseFactory.invalidSoftwareStatementErrorResponse("software_statement is not a valid JWT")
+        }
         def ssaClaims = ssaJwt.getClaimsSet();
 
         // Validate the issuer claim for the registration matches the SSA software_id


### PR DESCRIPTION
Handling InvalidJwtExceptions raised by JwtReconstruction for DCR registration request JWT and software_statement claim jwt.

This means that a HTTP 400 error is returned with an error msg, rather than a HTTP 500

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/641