### PR TITLE
655: Validating DCR redirect_uris

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -312,27 +312,28 @@ private void validateRegistrationRedirectUris(oidcRegistration, ssaClaims) {
     def regRedirectUris = oidcRegistration.getClaim("redirect_uris")
     def ssaRedirectUris = ssaClaims.getClaim("software_redirect_uris")
     if (!ssaRedirectUris || ssaRedirectUris.size() == 0) {
-        throw new IllegalStateException("software_statement must contain redirect_uris)")
+        throw new IllegalStateException("software_statement must contain redirect_uris")
     }
-    // If no redirect_uris supplied in reg request, then use the value from the SSA
+    // If no redirect_uris supplied in registration request, use all of the uris defined in software_redirect_uris
     if (!regRedirectUris || regRedirectUris.size() == 0) {
         oidcRegistration.setClaim("redirect_uris", ssaRedirectUris)
     } else {
-        // validate registration redirects are the same as, or a subset of, the ssa redirects
+        // validate registration redirects are the same as, or a subset of, software_redirect_uris
         if (regRedirectUris.size() > ssaRedirectUris.size()) {
             throw new IllegalStateException("invalid registration request redirect_uris value, must match or be a subset of the software_statement.redirect_uris")
         } else {
             for (regRedirect in regRedirectUris) {
+                def redirectUrl
                 try {
-                    def redirectUrl = new URL(regRedirect)
-                    if (!"https".equals(redirectUrl.getProtocol())) {
-                        throw new IllegalStateException("invalid registration request redirect_uris value: " + regRedirect + " must use https")
-                    }
-                    if ("localhost".equals(redirectUrl.getHost())) {
-                        throw new IllegalStateException("invalid registration request redirect_uris value: " + regRedirect + " must not point to localhost")
-                    }
+                    redirectUrl = new URL(regRedirect)
                 } catch (e) {
                     throw new IllegalStateException("invalid registration request redirect_uris value: " + regRedirect + " is not a valid URI")
+                }
+                if (!"https".equals(redirectUrl.getProtocol())) {
+                    throw new IllegalStateException("invalid registration request redirect_uris value: " + regRedirect + " must use https")
+                }
+                if ("localhost".equals(redirectUrl.getHost())) {
+                    throw new IllegalStateException("invalid registration request redirect_uris value: " + regRedirect + " must not point to localhost")
                 }
                 if (!ssaRedirectUris.contains(regRedirect)) {
                     throw new IllegalStateException("invalid registration request redirect_uris value, must match or be a subset of the software_statement.redirect_uris")

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -320,7 +320,7 @@ private void validateRegistrationRedirectUris(oidcRegistration, ssaClaims) {
     } else {
         // validate registration redirects are the same as, or a subset of, software_redirect_uris
         if (regRedirectUris.size() > ssaRedirectUris.size()) {
-            throw new IllegalStateException("invalid registration request redirect_uris value, must match or be a subset of the software_statement.redirect_uris")
+            throw new IllegalStateException("invalid registration request redirect_uris value, must match or be a subset of the software_redirect_uris")
         } else {
             for (regRedirect in regRedirectUris) {
                 def redirectUrl
@@ -336,7 +336,7 @@ private void validateRegistrationRedirectUris(oidcRegistration, ssaClaims) {
                     throw new IllegalStateException("invalid registration request redirect_uris value: " + regRedirect + " must not point to localhost")
                 }
                 if (!ssaRedirectUris.contains(regRedirect)) {
-                    throw new IllegalStateException("invalid registration request redirect_uris value, must match or be a subset of the software_statement.redirect_uris")
+                    throw new IllegalStateException("invalid registration request redirect_uris value, must match or be a subset of the software_redirect_uris")
                 }
             }
         }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -308,6 +308,10 @@ private boolean validateRegistrationJwtSignature(jwt, jwkSet) {
     }
 }
 
+/**
+ * Validate the redirect_uris claim in the registration request is valid as per the OB DCR spec:
+ * https://openbankinguk.github.io/dcr-docs-pub/v3.2/dynamic-client-registration.html
+ */
 private void validateRegistrationRedirectUris(oidcRegistration, ssaClaims) {
     def regRedirectUris = oidcRegistration.getClaim("redirect_uris")
     def ssaRedirectUris = ssaClaims.getClaim("software_redirect_uris")

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/securebanking/gateway/dcr/ErrorResponseFactory.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/securebanking/gateway/dcr/ErrorResponseFactory.groovy
@@ -30,6 +30,10 @@ class ErrorResponseFactory {
         return errorResponse(Status.BAD_REQUEST, "invalid_software_statement", errorMessage)
     }
 
+    def invalidRedirectUriErrorResponse(errorMessage) {
+        return errorResponse(Status.BAD_REQUEST, "invalid_redirect_uri", errorMessage)
+    }
+
     def errorResponse(httpCode, errorMessage) {
         return errorResponse(httpCode, null, errorMessage)
     }


### PR DESCRIPTION
The redirect_uris must match or be a subset of the software_statement.software_redirect_uris

If no redirect_uris are present in the registration request, then all the software_statement.software_redirect_uris will be used

The ob spec also requires that redirect_uris use https and do not have localhost as the host

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/655