### PR TITLE
683: Refactoring CreateApiClient to use Promise API correctly

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
@@ -4,9 +4,11 @@ import org.forgerock.json.jose.*
 import static org.forgerock.util.promise.Promises.newResultPromise
 
 /*
- * Filter to manage AM apiClient and apiClientOrg objects in IDM
+ * Filter to manage AM apiClient and apiClientOrg objects in IDM.
  *
- * All functionality is triggered upon a successful response from AM.
+ * All functionality is triggered upon a successful response from AM. Callers are attempting to do DCR or manage an
+ * existing registration, they are unaware of IDM specifics. Therefore, responses from this filter should be AM response
+ * objects or suitable error responses.
  *
  * New apiClient and apiClientOrg objects are created in IDM when a new DCR has been completed. Note, the apiClientOrg
  * may already exist, in which case only the apiClient is created. In both cases, the apiClient is linked to the apiClientOrg

--- a/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
@@ -4,7 +4,7 @@ import org.forgerock.json.jose.*
 import static org.forgerock.util.promise.Promises.newResultPromise
 
 /*
- * Filter to manage AM apiClient and apiClientOrg objects in IDM.
+ * Filter to manage apiClient and apiClientOrg objects in IDM.
  *
  * All functionality is triggered upon a successful response from AM. Callers are attempting to do DCR or manage an
  * existing registration, they are unaware of IDM specifics. Therefore, responses from this filter should be AM response

--- a/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
@@ -173,11 +173,12 @@ def createApiClientOrganisation(apiClientOrgIdmObject) {
   apiClientOrgRequest.setEntity(apiClientOrgIdmObject)
   return http.send(apiClientOrgRequest).then(apiClientOrgResponse -> {
     if (!apiClientOrgResponse.status.isSuccessful() && apiClientOrgResponse.status.code != HTTP_STATUS_PRECONDITION_FAILED) {
-      logger.error(SCRIPT_NAME + "unexpected IDM response when attempting to create {}, status: {}, entity: {}", routeArgObjApiClientOrgapiClientOrgResponse, apiClientOrgResponse.status, apiClientOrgResponse.entity)
+      logger.error(SCRIPT_NAME + "unexpected IDM response when attempting to create {}, status: {}, entity: {}", routeArgObjApiClientOrg, apiClientOrgResponse.status, apiClientOrgResponse.entity)
       return new Response(Status.INTERNAL_SERVER_ERROR)
     } else {
       logger.debug(SCRIPT_NAME + "organisation created OR already exists")
-      return new Response(Status.OK)
+      apiClientOrgResponse.status = Status.CREATED
+      return apiClientOrgResponse
     }
   })
 }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
@@ -173,6 +173,7 @@ def createApiClientOrganisation(apiClientOrgIdmObject) {
   apiClientOrgRequest.setUri(routeArgIdmBaseUri + "/openidm/managed/" + routeArgObjApiClientOrg + "/" + apiClientOrgIdmObject["_id"])
   apiClientOrgRequest.addHeaders(new GenericHeader("If-None-Match", "*")) // Prevent updating an existing apiClientOrg
   apiClientOrgRequest.setEntity(apiClientOrgIdmObject)
+  logger.debug(SCRIPT_NAME + "Attempting to create {} in IDM", routeArgObjApiClientOrg)
   return http.send(apiClientOrgRequest).then(apiClientOrgResponse -> {
     if (!apiClientOrgResponse.status.isSuccessful() && apiClientOrgResponse.status.code != HTTP_STATUS_PRECONDITION_FAILED) {
       logger.error(SCRIPT_NAME + "unexpected IDM response when attempting to create {}, status: {}, entity: {}", routeArgObjApiClientOrg, apiClientOrgResponse.status, apiClientOrgResponse.entity)
@@ -190,8 +191,7 @@ def createApiClient(apiClientIdmObject) {
   apiClientRequest.setMethod('POST')
   apiClientRequest.setUri(routeArgIdmBaseUri + "/openidm/managed/" + routeArgObjApiClient + "?_action=create")
   apiClientRequest.setEntity(apiClientIdmObject)
-
-  logger.debug(SCRIPT_NAME + "Sending apiClient create request to IDM endpoint")
+  logger.debug(SCRIPT_NAME + "Attempting to create {} in IDM", routeArgObjApiClient)
   return http.send(apiClientRequest).then(apiClientResponse -> {
     if (apiClientResponse.status != Status.CREATED) {
       logger.error(SCRIPT_NAME + "unexpected IDM response when attempting to create {}, status: {}, entity: {}", routeArgObjApiClient, apiClientResponse.status, apiClientResponse.entity)

--- a/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
@@ -15,7 +15,7 @@ import static org.forgerock.util.promise.Promises.newResultPromise
  */
 
 /**
- * 412 Precondition Failed: The resource’s current version does not match the version provided.
+ * HTTP 412 - Precondition Failed: The resource’s current version does not match the version provided.
  * Returned by IDM when this filter attempts to create an apiClientOrg that already exists
  * https://backstage.forgerock.com/docs/idm/7.2/crest/crest-status-codes.html
  */

--- a/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
@@ -6,12 +6,12 @@ import static org.forgerock.util.promise.Promises.newResultPromise
 /*
  * Filter to manage AM apiClient and apiClientOrg objects in IDM
  *
- * All functionality is trigger upon a successful response from AM.
+ * All functionality is triggered upon a successful response from AM.
  *
  * New apiClient and apiClientOrg objects are created in IDM when a new DCR has been completed. Note, the apiClientOrg
- * may already exist, in which case only the apiClient is created.
+ * may already exist, in which case only the apiClient is created. In both cases, the apiClient is linked to the apiClientOrg
  *
- * Get and Delete operations are also supported and retrieve existing apiClient records from IDM.
+ * Get and Delete operations are also supported for existing IDM apiClient objects
  */
 
 /**


### PR DESCRIPTION
Changes to CreateApiClient POST handling:
- Properly chained Promises using thenAsync when making http calls in response handling i.e. calling IDM as part of handling the AM response
- Fixed error handling
  - Return Response objects or Promises wrapping Response objects as appropriate
  - Unexpected errors from IDM will bubble up as HTTP 500 errors
- Changed order of calls to create the apiClientOrg first (if it does not already exist), then creating the apiClient
  - Using a PUT with header "If-None-Match: *" to prevent existing apiClientOrg objects being overwritten

Useful CREST documentation:
https://backstage.forgerock.com/docs/idm/7.2/crest/crest-create.html
https://backstage.forgerock.com/docs/idm/7.2/crest/crest-status-codes.html

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/683