### PR TITLE
656: Support PUT in CreateApiClient filter

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
@@ -64,12 +64,12 @@ switch(method.toUpperCase()) {
         return newResultPromise(errorResponse(Status.INTERNAL_SERVER_ERROR, "Missing request data"))
       }
 
-      def ssaClaims = attributes.registrationJWTs.ssaJwt.getClaimsSet()
       def oauth2ClientId = amResponse.entity.getJson().client_id
       if (!oauth2ClientId) {
         logger.error(SCRIPT_NAME + "Required client_id field not found in AM registration response")
         return newResultPromise(errorResponse(Status.INTERNAL_SERVER_ERROR, "Failed to get client_id"))
       }
+      def ssaClaims = attributes.registrationJWTs.ssaJwt.getClaimsSet()
       def apiClientIdmObject = buildApiClientIdmObject(oauth2ClientId, ssaClaims)
       def apiClientOrgIdmObject = buildApiClientOrganisationIdmObject(ssaClaims)
 

--- a/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
@@ -90,8 +90,8 @@ switch(method.toUpperCase()) {
         } else {
           // Updating a DCR, update apiClient data in IDM
           return updateApiClient(apiClientIdmObject).then(updateApiClientResponse -> {
-            if (!createApiClientResponse.status.isSuccessful()) {
-              return createApiClientResponse
+            if (!updateApiClientResponse.status.isSuccessful()) {
+              return updateApiClientResponse
             } else {
               // Return the original AM success response if we updated the IDM objects
               return amResponse


### PR DESCRIPTION
PUT is used to update an existing DCR.

The CreateApiClient filter needs to update the IDM apiClient object for the DCR being updated. This logic is done on the response path (same as for POST), so that we only do the update if AM accepted the DCR update.

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/656