### PR TITLE
690: Restrict token_endpoint_auth_methods_supported

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -2,6 +2,9 @@
   "properties": {
     "security": {
       "allowIgIssuedTestCerts": true
+    },
+    "oauth2": {
+      "tokenEndpointAuthMethodsSupported": ["private_key_jwt"]
     }
   },
   "handler": "_router",

--- a/config/7.1.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/prod/config/config.json
@@ -2,6 +2,9 @@
   "properties": {
     "security": {
       "allowIgIssuedTestCerts": false
+    },
+    "oauth2": {
+      "tokenEndpointAuthMethodsSupported": ["private_key_jwt"]
     }
   },
   "handler": {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/02-ob-as-metadata.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/02-ob-as-metadata.json
@@ -10,6 +10,18 @@
       "filters": [
         "SBATFapiInteractionFilterChain",
         {
+          "comment": "Update AS well-known config returned by AM",
+          "name": "ASWellKnownFilter",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ASWellKnownFilter.groovy",
+            "args": {
+              "tokenEndpointAuthMethodsSupported": "${oauth2.tokenEndpointAuthMethodsSupported}"
+            }
+          }
+        },
+        {
           "comment": "Set downstream Host header",
           "name" : "HeaderFilter-ChangeHostToIAM",
           "type" : "HeaderFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -53,7 +53,8 @@
               "routeArgProxyBaseUrl": "https://&{ig.fqdn}/jwkms/jwksproxy",
               "jwkSetService": "${heap['OBJwkSetService']}",
               "allowIgIssuedTestCerts": "${security.allowIgIssuedTestCerts}",
-              "jwtSignatureValidator": "${heap['RsaJwtSignatureValidator']}"
+              "jwtSignatureValidator": "${heap['RsaJwtSignatureValidator']}",
+              "tokenEndpointAuthMethodsSupported": "${oauth2.tokenEndpointAuthMethodsSupported}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ASWellKnownFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ASWellKnownFilter.groovy
@@ -1,0 +1,14 @@
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if (fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[ASWellKnownFilter] (" + fapiInteractionId + ") - ";
+
+logger.debug(SCRIPT_NAME + "Running...")
+
+next.handle(context, request).thenOnResult(response -> {
+    if (response.status.isSuccessful()) {
+        wellKnownData = response.entity.getJson()
+        // Configure auth methods supported using filter arg: tokenEndpointAuthMethodsSupported
+        wellKnownData["token_endpoint_auth_methods_supported"] = tokenEndpointAuthMethodsSupported
+        response.entity.setJson(wellKnownData)
+    }
+})

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -74,7 +74,7 @@ switch(method.toUpperCase()) {
 
         def tokenEndpointAuthMethod = oidcRegistration.getClaim("token_endpoint_auth_method")
         if (!tokenEndpointAuthMethod || !tokenEndpointAuthMethodsSupported.contains(tokenEndpointAuthMethod)) {
-            return errorResponseFactory.invalidClientMetadataErrorResponse("token_endpoint_auth_method claim must be one of: " + supportedTokenEndpointAuthMethods)
+            return errorResponseFactory.invalidClientMetadataErrorResponse("token_endpoint_auth_method claim must be one of: " + tokenEndpointAuthMethodsSupported)
         }
 
         def ssa = oidcRegistration.getClaim("software_statement", String.class);

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -72,6 +72,11 @@ switch(method.toUpperCase()) {
             return errorResponseFactory.invalidClientMetadataErrorResponse("response_types: " + responseTypes + " not supported")
         }
 
+        def tokenEndpointAuthMethod = oidcRegistration.getClaim("token_endpoint_auth_method")
+        if (!tokenEndpointAuthMethod || !tokenEndpointAuthMethodsSupported.contains(tokenEndpointAuthMethod)) {
+            return errorResponseFactory.invalidClientMetadataErrorResponse("token_endpoint_auth_method claim must be one of: " + supportedTokenEndpointAuthMethods)
+        }
+
         def ssa = oidcRegistration.getClaim("software_statement", String.class);
         if (!ssa) {
             return errorResponseFactory.invalidSoftwareStatementErrorResponse("software_statement claim is missing")


### PR DESCRIPTION
- Adding ASWellKnownFilter to modify the AM well-known response to restrict the token_endpoint_auth_methods_supported values
- Adding oauth2.tokenEndpointAuthMethodsSupported IG config to control the above
  - Configuring private_key_jwt as the only supported value. FAPI also allows tls_client_auth but this is not supported by SAPI-G yet.
- Validating DCR request against the supported auth methods

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/690