### PR TITLE
302: Fix deployment of IG on push of PR

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,7 +64,7 @@ jobs:
       - name: 'build environment and run functional tests'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:
-          args: '-v TAG=${{ env.PR_NUMBER }} -v SERVICE_NAME=${{ env.SERVICE_NAME }} -v ENVIRONMENT=${{ env.GITHUB_USER }} -v BRANCH=${{ github.head_ref }}'
+          args: '-v TAG=${{ env.PR_NUMBER }} -v SERVICE_NAME=${{ env.SERVICE_NAME }} -v ENVIRONMENT=${{ env.GITHUB_USER }}'
         env:
           PIPELINE_NAME: 'ForgeCloud/sbat-infra/service-build'
           CF_API_KEY: ${{ secrets.CF_API_KEY }}


### PR DESCRIPTION
The branch from which the deploy is being made now relates to the branch of sapig-openbanking-uk-developer-envs, not the IG repo branch, so we should not override this

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/302