### PR TITLE
676: Ensure authorize request jwt conforms to FAPI spec

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
@@ -33,9 +33,6 @@
           "config": {
             "type": "application/x-groovy",
             "file": "FapiCompliantAuthorizeRequestFilter.groovy",
-            "args": {
-              "comment": "TODO: use env variable"
-            }
           }
         }        
       ],

--- a/config/7.1.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
@@ -32,7 +32,7 @@
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
-            "file": "FapiCompliantAuthorizeRequestFilter.groovy",
+            "file": "FapiCompliantAuthorizeRequestFilter.groovy"
           }
         }        
       ],

--- a/config/7.1.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
@@ -1,0 +1,45 @@
+{
+  "comment": "Ensure FAPI compliant authorize requests",
+  "name": "04 - Open Banking Authorize endpoint",
+  "auditService": "AuditService-OB-Route",
+  "baseURI": "https://&{identity.platform.fqdn}",
+  "condition": "${matches(request.uri.path, '^/am/oauth2/realms/root/realms/&{am.realm}/authorize')}",
+  "handler": {
+    "type": "Chain",
+    "config": {
+      "filters": [
+        "SBATFapiInteractionFilterChain",
+        {
+          "comment": "Add host to downstream request",
+          "name": "HeaderFilter-ChangeHostToIAM",
+          "type": "HeaderFilter",
+          "config": {
+            "messageType": "REQUEST",
+            "remove": [
+              "host",
+              "X-Forwarded-Host"
+            ],
+            "add": {
+              "X-Forwarded-Host": [
+                "&{ig.fqdn}"
+              ]
+            }
+          }
+        },
+        {
+          "comment": "Ensure authorize request object is FAPI compliant",
+          "name": "FapiAuthorizeRequestFilter",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "FapiCompliantAuthorizeRequestFilter.groovy",
+            "args": {
+              "comment": "TODO: use env variable"
+            }
+          }
+        }        
+      ],
+      "handler": "SBATReverseProxyHandlerIdentityPlatform"
+    }
+  }
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
@@ -1,0 +1,187 @@
+import org.forgerock.json.jose.jws.SignedJwt
+import org.forgerock.json.jose.common.JwtReconstruction
+import org.forgerock.json.jose.jwt.JwtClaimsSet
+import org.forgerock.http.protocol.Status
+import com.forgerock.sapi.gateway.jwt.JwtClaimNames
+import com.forgerock.sapi.gateway.rest.HttpRequestParameterNames
+import com.forgerock.sapi.gateway.oauth.OAuthErrorResponseFactory
+
+
+/**
+ * This script checks that the call to the /authorize endpoint is
+ * correctly formed and valid.
+ *
+ * Relevant specifications:
+ * OAuth 2.0 spec: https://www.rfc-editor.org/rfc/rfc6749#section-4.1
+ * FAPI Part 1: https://openid.net/specs/openid-financial-api-part-1-1_0.html#authorization-server
+ * FAPI Part 2: https://openid.net/specs/openid-financial-api-part-2-1_0.html#authorization-server
+ *
+ *
+ */
+
+def fapiInteractionId = request.getHeaders().getFirst('x-fapi-interaction-id')
+if (fapiInteractionId == null) fapiInteractionId = 'No x-fapi-interaction-id'
+SCRIPT_NAME = '[FapiCompliantAuthorizeRequestFilter] (' + fapiInteractionId + ') - '
+logger.debug(SCRIPT_NAME + 'Running...')
+
+String httpMethod = request.method
+Header acceptHeader = request.getHeaders().get('accept')
+
+OAuthErrorResponseFactory errorResponseFactory = new OAuthErrorResponseFactory(SCRIPT_NAME)
+
+switch (httpMethod.toUpperCase()) {
+    case 'GET':
+    case 'POST':
+        // Parse incoming registration JWT
+        logger.debug(SCRIPT_NAME + 'Parsing authorize request')
+
+        // From the OAuth 2.0 Spec:
+        //   If the request fails due to a missing, invalid, or mismatching
+        //   redirection URI, or if the client identifier is missing or invalid,
+        //   the authorization server SHOULD inform the resource owner of the
+        //   error and MUST NOT automatically redirect the user-agent to the
+        //   invalid redirection URI.
+        //
+        // From the FAPI Part 1 Spec:
+        //   Shall only use the parameters included in the signed request object passed via the request or request_uri
+        //   parameter
+        JwtClaimsSet requestJwtClaimSet = getRequestJtwClaimSet()
+        if (!requestJwtClaimSet) {
+            Form errorForm = new Form(["error_description": ["Request must have a 'request' query parameter the value of which must be a signed jwt"]])
+            return errorResponseFactory.invalidRequestErrorResponse(acceptHeader, errorForm)
+        }
+
+        Response errorResponse = isRequestValidForRedirection(requestJwtClaimSet, acceptHeader, errorResponseFactory)
+        if (errorResponse) {
+            return errorResponse
+        }
+
+        // ToDo - any failures of tests after this point should result in errors being sent to the redirect URI.
+        // However, we haven't yet validated the requestJwt so we can't truly trust it. We leave AM to do the 
+        // JWT validation. 
+        // The OAuth spec says this about errors:
+        //   If the resource owner denies the access request or if the request
+        //   fails for reasons other than a missing or invalid redirection URI,
+        //   the authorization server informs the client by adding the following
+        //   parameters to the query component of the redirection URI using the
+        //   "application/x-www-form-urlencoded" format, per Appendix B:
+        // However, the FAPI Advanced Part 1 compliance suite indicates that it is OK to simply show an error in
+        // response to the request - which is what we will do for now. These tests really need to be rolled into
+        // ForgeRock AM as a FAPI compliant option.
+
+        // Spec covering the necessity of these fields to exist in the authorization request:
+        // scope - The FAPI Advanced part 1 spec, section 5.2.2.1 states that
+        //   "if it is desired to provide the  authenticated user's identifier to the client
+        //   in the token response, the authorization server:
+        //   1. shall support the authentication request as in Section 3.1.2.1 of OIDC
+        //   (see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)
+        //
+        // The OIDC spec states that scope, response_type, client_id and redirect are required.
+        // -------------------------
+        // FAPI Advanced Part 1, part 5.2.2.3
+        //   "1. shall require the nonce parameter defined in Section 3.1.2.1 of OIDC in the authentication request"
+        // (see https://openid.net/specs/openid-financial-api-part-1-1_0.html#client-requesting-openid-scope)
+        String[] requiredClaims = [ JwtClaimNames.SCOPE, JwtClaimNames.NONCE, JwtClaimNames.RESPONSE_TYPE ]
+        for (requiredClaim in requiredClaims) {
+            if (!requestJwtHasClaim(requiredClaim, requestJwtClaimSet)) {
+                Form errorForm = new Form(["error_description": ["Request JWT must have a '" + requiredClaim + "' claim"]])
+                logger.info("{} Creating invalidRequestErrorResponse: {}", errorForm)
+                return errorResponseFactory.invalidRequestErrorResponse(acceptHeader, errorForm)
+            }
+        }
+
+        // Should be ignoring and not returning state if it only exists as a http request parameter and does not
+        // exist in the request jwt. AM however doesn't apply this rule and returns state in the resulting redirect
+        //
+        // The solution is to remove it from the request sent to AM so that there is no state supplied.
+        removeStateFromRequestIfNotInRequestJwt(requestJwtClaimSet)
+
+        break
+    default:
+        logger.debug(SCRIPT_NAME + 'Method not supported')
+        return new Response(Status.NOT_FOUND)
+}
+
+logger.info('Request is FAPI compliant - calling next.handle')
+return next.handle(context, request)
+
+/**
+ * Checks if we have sufficient trust to be able to send errors to the redirect_uri. Currently this 
+ * not very useful as we have done no validation of the SSA signature, so we must return all subsequent
+ * errors to the original caller rather than calling the redirect_uri. However it does at least serve
+ * as a requirement should AM ever use this script as a basis for building FAPI compliant settings for
+ * the authorization endpoint... or maybe if the become a problem we can build SSA validation into the 
+ * as-authorize route config before calling this script so we can trust the SSA. Then we could change
+ * subsequent error handling to add the error fields to the redirect_uri.
+ */
+private Response isRequestValidForRedirection(JwtClaimsSet requestJwtClaims,
+                                              Header acceptHeader, OAuthErrorResponseFactory errorResponseFactory) {
+    String[] requiredClaims = [ JwtClaimNames.REDIRECT_URI, JwtClaimNames.CLIENT_ID ]
+    for ( requiredClaim in requiredClaims ) {
+        if (!requestJwtHasClaim(requiredClaim, requestJwtClaims) ) {
+            Form errorForm = new Form(["error_description": ["Request JWT must have a '" + requiredClaim + "' claim"]])
+            logger.info("{} Creating invalidRequestErrorResponse: {}", errorForm)
+            return errorResponseFactory.invalidRequestErrorResponse(acceptHeader, errorForm)
+        }
+    }
+    return null
+}
+
+/**
+ * Checks if the claim exists in the requestJwtClaimSet
+ */
+private Boolean requestJwtHasClaim(String claimName, JwtClaimsSet requestJwtClaims) {
+    return requestJwtClaims.getClaim(claimName) ? true : false
+}
+
+
+private void removeStateFromRequestIfNotInRequestJwt(JwtClaimsSet requestJwtClaimSet) {
+    String stateClaimName = 'state'
+    if (!requestJwtHasClaim(stateClaimName, requestJwtClaimSet)) {
+        String stateQueryParam = getQueryParamFromRequest(stateClaimName)
+        if (stateQueryParam) {
+            logger.info("{}Removing state request parameter as no state claim in request jwt", SCRIPT_NAME)
+            Form existingQueryParams = request.getQueryParams()
+            existingQueryParams.remove(stateClaimName)
+            existingQueryParams.toRequestQuery(request)
+        }
+    }
+}
+
+private JwtClaimsSet getRequestJtwClaimSet() {
+    String requestJwtString  = getQueryParamFromRequest(HttpRequestParameterNames.REQUEST)
+    if (!requestJwtString) {
+        logger.info('{}/authorize request must have a request query parameter', SCRIPT_NAME)
+        return null
+    }
+    try {
+        SignedJwt jwt = new JwtReconstruction().reconstructJwt(requestJwtString, SignedJwt.class)
+        return jwt.getClaimsSet()
+    }
+    catch (e) {
+        logger.info(SCRIPT_NAME + 'BAD_REQUEST: Could not parse request JWT string', e)
+        return null
+    }
+}
+
+/**
+ *  Returns null if the parameter does not exist. Throws IllegalStateException if more than one query parameter with
+ *  this name exists
+ */
+private String getQueryParamFromRequest(String paramName) {
+    logger.debug("{}Obtaining query param with name '{}' from request", SCRIPT_NAME, paramName)
+    String[] value = request.getQueryParams().get(paramName)
+
+    if ( !value ) {
+        logger.info("{} No query parameter of name '{}' exists in the request", SCRIPT_NAME, paramName)
+        return null
+    }
+
+    if ( value.size() != 1 ) {
+        logger.info("{}There are '{}' values for request parameter '{}'", SCRIPT_NAME, value.size(), paramName)
+        return null
+    }
+    logger.debug("{} Value of query param '{}' is '{}'", SCRIPT_NAME, paramName, value)
+    return value[0]
+}
+

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
@@ -4,6 +4,7 @@ import org.forgerock.json.jose.jwt.JwtClaimsSet
 import org.forgerock.http.protocol.Status
 import com.forgerock.sapi.gateway.jwt.JwtClaimNames
 import com.forgerock.sapi.gateway.rest.HttpRequestParameterNames
+import com.forgerock.sapi.gateway.rest.HttpHeaderNames
 import com.forgerock.sapi.gateway.oauth.OAuthErrorResponseFactory
 
 

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
@@ -1,3 +1,4 @@
+import com.forgerock.sapi.gateway.rest.content.ContentTypeFormatterFactory
 import org.forgerock.json.jose.jws.SignedJwt
 import org.forgerock.json.jose.common.JwtReconstruction
 import org.forgerock.json.jose.jwt.JwtClaimsSet
@@ -27,8 +28,9 @@ logger.debug(SCRIPT_NAME + 'Running...')
 
 String httpMethod = request.method
 Header acceptHeader = request.getHeaders().get('accept')
+ContentTypeFormatterFactory contentTypeFormatterFactory = new ContentTypeFormatterFactory()
 
-OAuthErrorResponseFactory errorResponseFactory = new OAuthErrorResponseFactory(SCRIPT_NAME)
+OAuthErrorResponseFactory errorResponseFactory = new OAuthErrorResponseFactory(SCRIPT_NAME, contentTypeFormatterFactory)
 
 switch (httpMethod.toUpperCase()) {
     case 'GET':

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
@@ -19,8 +19,8 @@ import com.forgerock.sapi.gateway.oauth.OAuthErrorResponseFactory
  *
  */
 
-def fapiInteractionId = request.getHeaders().getFirst('x-fapi-interaction-id')
-if (fapiInteractionId == null) fapiInteractionId = 'No x-fapi-interaction-id'
+def fapiInteractionId = request.getHeaders().getFirst(HttpHeaderNames.X_FAPI_INTERACTION_ID)
+if (fapiInteractionId == null) fapiInteractionId = 'No ' + HttpHeaderNames.X_FAPI_INTERACTION_ID
 SCRIPT_NAME = '[FapiCompliantAuthorizeRequestFilter] (' + fapiInteractionId + ') - '
 logger.debug(SCRIPT_NAME + 'Running...')
 
@@ -47,8 +47,8 @@ switch (httpMethod.toUpperCase()) {
         //   parameter
         JwtClaimsSet requestJwtClaimSet = getRequestJtwClaimSet()
         if (!requestJwtClaimSet) {
-            Form errorForm = new Form(["error_description": ["Request must have a 'request' query parameter the value of which must be a signed jwt"]])
-            return errorResponseFactory.invalidRequestErrorResponse(acceptHeader, errorForm)
+            String errorDescription = "Request must have a 'request' query parameter the value of which must be a signed jwt"
+            return errorResponseFactory.invalidRequestErrorResponse(acceptHeader, errorDescription)
         }
 
         Response errorResponse = isRequestValidForRedirection(requestJwtClaimSet, acceptHeader, errorResponseFactory)
@@ -84,9 +84,8 @@ switch (httpMethod.toUpperCase()) {
         String[] requiredClaims = [ JwtClaimNames.SCOPE, JwtClaimNames.NONCE, JwtClaimNames.RESPONSE_TYPE ]
         for (requiredClaim in requiredClaims) {
             if (!requestJwtHasClaim(requiredClaim, requestJwtClaimSet)) {
-                Form errorForm = new Form(["error_description": ["Request JWT must have a '" + requiredClaim + "' claim"]])
-                logger.info("{} Creating invalidRequestErrorResponse: {}", errorForm)
-                return errorResponseFactory.invalidRequestErrorResponse(acceptHeader, errorForm)
+                String errorDescription = "Request JWT must have a '" + requiredClaim + "' claim"
+                return errorResponseFactory.invalidRequestErrorResponse(acceptHeader, errorDescription)
             }
         }
 
@@ -99,7 +98,7 @@ switch (httpMethod.toUpperCase()) {
         break
     default:
         logger.debug(SCRIPT_NAME + 'Method not supported')
-        return new Response(Status.NOT_FOUND)
+        return new Response(Status.METHOD_NOT_ALLOWED)
 }
 
 logger.info('Request is FAPI compliant - calling next.handle')
@@ -119,9 +118,8 @@ private Response isRequestValidForRedirection(JwtClaimsSet requestJwtClaims,
     String[] requiredClaims = [ JwtClaimNames.REDIRECT_URI, JwtClaimNames.CLIENT_ID ]
     for ( requiredClaim in requiredClaims ) {
         if (!requestJwtHasClaim(requiredClaim, requestJwtClaims) ) {
-            Form errorForm = new Form(["error_description": ["Request JWT must have a '" + requiredClaim + "' claim"]])
-            logger.info("{} Creating invalidRequestErrorResponse: {}", errorForm)
-            return errorResponseFactory.invalidRequestErrorResponse(acceptHeader, errorForm)
+            String errorDescription = "Request JWT must have a '" + requiredClaim + "' claim"
+            return errorResponseFactory.invalidRequestErrorResponse(acceptHeader, errorDescription)
         }
     }
     return null

--- a/config/7.1.0/securebanking/ig/scripts/groovy/GrantTypeVerifier.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/GrantTypeVerifier.groovy
@@ -1,23 +1,23 @@
 import org.forgerock.http.protocol.*
+import com.forgerock.sapi.gateway.rest.HttpHeaderNames
 
-def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
-if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
-SCRIPT_NAME = "[GrantTypeVerifier] (" + fapiInteractionId + ") - ";
-logger.debug(SCRIPT_NAME + "Running...")
+String fapiInteractionId = request.getHeaders().getFirst(HttpHeaderNames.X_FAPI_INTERACTION_ID);
+if (fapiInteractionId == null) { fapiInteractionId = 'No ' + HttpHeaderNames.X_FAPI_INTERACTION_ID + ' header'}
+SCRIPT_NAME = '[GrantTypeVerifier] (' + fapiInteractionId + ') - '
+logger.debug(SCRIPT_NAME + 'Running...')
 
-def tokenGrantType = contexts.oauth2.accessToken.info.grant_type
-logger.debug(SCRIPT_NAME + "Access token info: " + contexts.oauth2.accessToken.info)
-logger.debug(SCRIPT_NAME + "Token grant type: " + tokenGrantType)
+String tokenGrantType = contexts.oauth2.accessToken.info.grant_type
+logger.debug(SCRIPT_NAME + 'Access token info: ' + contexts.oauth2.accessToken.info)
+logger.debug(SCRIPT_NAME + 'Token grant type: ' + tokenGrantType)
 
-if (tokenGrantType == allowedGrantType) {
+if (allowedGrantType.contains(tokenGrantType) 
+    || (allowedGrantType == 'authorization_code' && tokenGrantType == 'refresh_token')) {
     next.handle(context, request)
 } else {
     Response response = new Response(Status.UNAUTHORIZED)
-    def message = "invalid_grant_type"
+    String message = 'invalid_grant_type'
     logger.error(SCRIPT_NAME + message)
-    response.headers['Content-Type'] = "application/json"
+    response.headers['Content-Type'] = 'application/json'
     response.entity = "{ \"error\":\"" + message + "\"}"
-    return response;
+    return response
 }
-
-

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/jwt/JwtClaimNames.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/jwt/JwtClaimNames.groovy
@@ -1,0 +1,14 @@
+package com.forgerock.sapi.gateway.jwt
+
+/**
+ * Class containing string constants decribing FAPI related JWT claim names
+ */
+public class JwtClaimNames {
+
+    static final String CLIENT_ID = 'client_id'
+    static final String NONCE = 'nonce'
+    static final String SCOPE = 'scope'
+    static final String RESPONSE_TYPE = 'response_type'
+    static final String REDIRECT_URI = 'redirect_uri'
+
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/oauth/OAuthErrorResponseFactory.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/oauth/OAuthErrorResponseFactory.groovy
@@ -1,0 +1,170 @@
+package com.forgerock.sapi.gateway.oauth
+
+import org.forgerock.util.promise.*
+import org.forgerock.http.protocol.*
+import com.forgerock.sapi.gateway.rest.ContentTypeNegotiator
+import com.forgerock.sapi.gateway.rest.HttpMediaTypes
+import org.forgerock.http.util.Json
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * Factory which creates Response objects for error states when validating a DCR (Dynamic Client Registration) request
+ */
+class OAuthErrorResponseFactory {
+
+    List<String> supportedMediaTypes = [ HttpMediaTypes.TEXT_HTML, HttpMediaTypes.APPLICATION_TEXT,
+        HttpMediaTypes.APPLICATION_JSON, HttpMediaTypes.APPLICATION_FORM_URLENCODED, HttpMediaTypes.ALL_TYPES ]
+
+    private final Logger logger = LoggerFactory.getLogger(getClass())
+    private final ContentTypeNegotiator contentTypeNegotiator;
+
+    /**
+     * Prefix for log messages created by this factory.
+     * This is allows the x-fapi-interaction-id to be logged.
+     */
+    private final String logPrefix
+
+    public OAuthErrorResponseFactory(String logPrefix) {
+        this.logPrefix = logPrefix
+        this.supportedMediaTypes = supportedMediaTypes
+        this.contentTypeNegotiator = new ContentTypeNegotiator(logPrefix, supportedMediaTypes)
+    }
+
+    Response invalidRequestErrorResponse(Header acceptHeader, Form errorForm) {
+        String bestContentType = contentTypeNegotiator.getBestContentType(acceptHeader)
+        errorForm.add("error", "invalid_request")
+        return errorResponse(Status.BAD_REQUEST, errorForm, bestContentType)
+    }
+
+     Response invalidClientErrorResponse(Header acceptHeader, Form errorForm) {
+         String bestContentType = contentTypeNegotiator.getBestContentType(acceptHeader)
+         errorForm.add("error", "invalid_client")
+         return errorResponse(Status.BAD_REQUEST, errorForm, bestContentType)
+     }
+
+     Response invalidGrantErrorResponse(Header acceptHeader, Form errorForm) {
+         String bestContentType = contentTypeNegotiator.getBestContentType(acceptHeader)
+         errorForm.add("error", "invalid_grant")
+         return errorResponse(Status.BAD_REQUEST, errorForm, bestContentType)
+     }
+
+     Response unsupportedGrantTypeErrorResponse(Header acceptHeader, Form errorForm) {
+         String bestContentType = contentTypeNegotiator.getBestContentType(acceptHeader)
+         errorForm.add("error", "invalid_grant")
+         return errorResponse(Status.BAD_REQUEST, errorForm, bestContentType)
+     }
+
+     Response unauthorizedClientErrorResponse(Header acceptHeader, Form errorForm) {
+         String bestContentType = contentTypeNegotiator.getBestContentType(acceptHeader)
+         errorForm.add("error", "unauthorized_client")
+         return errorResponse(Status.BAD_REQUEST, errorForm, bestContentType)
+     }
+
+     Response invalidScopeErrorResponse(Header acceptHeader, Form errorForm) {
+         String bestContentType = contentTypeNegotiator.getBestContentType(acceptHeader)
+         errorForm.add("error", "invalid_scope")
+         return errorResponse(Status.BAD_REQUEST, errorForm, bestContentType)
+     }
+
+    Response errorResponse(Status httpCode, Form errorForm, String bestContentType) {
+        String errorMessage = getErrorMessage(errorForm, bestContentType)
+        logger.warn("{} creating OAuth Error Response, http status: {}, error: {}", logPrefix, httpCode, errorMessage)
+        Response response = new Response(httpCode)
+        response.entity.setString(errorMessage)
+        ContentTypeHeader mediaTypeHeader = new ContentTypeHeader(bestContentType, [:])
+        response.addHeaders(mediaTypeHeader)
+        return response
+    }
+
+    String getErrorMessage(Form errorForm, String bestContentType) {
+        if(bestContentType == HttpMediaTypes.TEXT_HTML) {
+            return getHtmlErrorMessage(errorForm)
+        } else if (bestContentType == HttpMediaTypes.APPLICATION_FORM_URLENCODED) {
+            return getFormUrlEncodedErrorMessage(errorForm)
+        } else if (bestContentType == HttpMediaTypes.APPLICATION_TEXT) {
+            return getTextErrorMessage(errorForm)
+        } else {
+            return getJsonErrorMessage(errorForm)
+        }
+    }
+
+    String getHtmlErrorMessage(Form errorForm) {
+        logger.debug("{}getHtmlErrorMessage, errorForm: '{}'", logPrefix,  errorForm)
+        StringBuilder errorMessageBuilder = new StringBuilder("<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Authorization Error" + 
+          "</title><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"></head><body>")
+        errorForm.forEach( (key, val) -> {
+            logger.debug("{}processing entry for {}, val is {}", logPrefix, key, val)
+            errorMessageBuilder.append("<p>" + key + ": ")
+            List<String> values = val
+            Boolean first = true
+            values.forEach( (innerVal) -> {
+                logger.debug("{}adding value {} to error message", logPrefix, innerVal)
+                if(!first){
+                    errorMessageBuilder.append(', ')
+                    first = false
+                }
+                errorMessageBuilder.append(innerVal)
+            })
+            errorMessageBuilder.append('</p>')
+        } )
+        errorMessageBuilder.append("</body></html>")
+        String htmlErrorMessage =  errorMessageBuilder.toString()
+        logger.debug("{}html error message is {}", logPrefix, htmlErrorMessage)
+        return htmlErrorMessage
+    }
+
+    String getJsonErrorMessage(Form errorForm){
+        logger.debug("{}getJsonErrorMessage, errorForm: '{}'", logPrefix, errorForm)
+        String jsonErrorMessage = new String(Json.writeJson(errorForm))
+        logger.debug("{}html error message is {}", logPrefix, jsonErrorMessage)
+        return jsonErrorMessage
+    }
+
+    String getTextErrorMessage(Form errorForm) {
+        logger.debug("{}getTextErrorMessage, errorForm: '{}'", logPrefix, errorForm)
+        StringBuilder errorMessageBuilder = new StringBuilder()
+        errorForm.forEach( (key, val) -> {
+            logger.debug("{}processing entry for {}, val is {}", logPrefix, key, val)
+            errorMessageBuilder.append(key + ": ")
+            List<String> values = val
+            Boolean first = true
+            values.forEach( (innerVal) -> {
+                logger.debug("{}adding value {} to error message", logPrefix, innerVal)
+                if(!first){
+                    errorMessageBuilder.append(', ')
+                    first = false
+                }
+                errorMessageBuilder.append(innerVal)
+            })
+            errorMessageBuilder.append('\n')
+        } )
+        String textErrorMessage =  errorMessageBuilder.toString()
+        logger.debug("{}text error message is {}", logPrefix, textErrorMessage)
+        return textErrorMessage
+    }
+
+    String getFormUrlEncodedErrorMessage(Form errorForm) {
+        logger.debug("{}getFormUrlEncodedErrorMessage, errorForm: '{}'", logPrefix, errorForm)
+        StringBuilder errorMessageBuilder = new StringBuilder()
+        errorForm.forEach( (key, val) -> {
+            logger.debug("{}processing entry for {}, val is {}", logPrefix, key, val)
+            errorMessageBuilder.append(key + "=")
+            List<String> values = val
+            Boolean first = true
+            values.forEach( (innerVal) -> {
+                logger.debug("{}adding value {} to error message", logPrefix, innerVal)
+                if(!first){
+                    errorMessageBuilder.append(',')
+                    first = false
+                }
+                errorMessageBuilder.append(innerVal)
+            })
+            errorMessageBuilder.append('&')
+        } )
+        String formUrlEncodedErrorMessage =  URLEncoder.encode(errorMessageBuilder.toString(), 'UTF-8')
+        logger.debug("{}form URL encoded error message is {}", logPrefix, formUrlEncodedErrorMessage)
+        return formUrlEncodedErrorMessage
+    }
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/oauth/OAuthErrorResponseFactory.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/oauth/OAuthErrorResponseFactory.groovy
@@ -1,10 +1,9 @@
 package com.forgerock.sapi.gateway.oauth
 
-import org.forgerock.util.promise.*
-import org.forgerock.http.protocol.*
-import com.forgerock.sapi.gateway.rest.ContentTypeNegotiator
+import com.forgerock.sapi.gateway.rest.content.ContentTypeFormatter
+import com.forgerock.sapi.gateway.rest.content.ContentTypeFormatterFactory
+import com.forgerock.sapi.gateway.rest.content.ContentTypeNegotiator
 import com.forgerock.sapi.gateway.rest.HttpMediaTypes
-import org.forgerock.http.util.Json
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -33,11 +32,13 @@ class OAuthErrorResponseFactory {
      * This is allows the x-fapi-interaction-id to be logged.
      */
     private final String logPrefix
+    private final ContentTypeFormatterFactory messageFormatterFactory
 
-    public OAuthErrorResponseFactory(String logPrefix) {
+    public OAuthErrorResponseFactory(String logPrefix, ContentTypeFormatterFactory messageFormatterFactory) {
         this.logPrefix = logPrefix
         this.supportedMediaTypes = supportedMediaTypes
         this.contentTypeNegotiator = new ContentTypeNegotiator(logPrefix, supportedMediaTypes)
+        this.messageFormatterFactory = messageFormatterFactory
     }
 
     Response invalidRequestErrorResponse(Header acceptHeader, String errorDescription) {
@@ -83,77 +84,7 @@ class OAuthErrorResponseFactory {
     }
 
     String getErrorMessage(Form errorForm, String bestContentType) {
-        if(bestContentType == HttpMediaTypes.TEXT_HTML) {
-            return getHtmlErrorMessage(errorForm)
-        } else if (bestContentType == HttpMediaTypes.APPLICATION_FORM_URLENCODED) {
-            return getFormUrlEncodedErrorMessage(errorForm)
-        } else if (bestContentType == HttpMediaTypes.APPLICATION_TEXT) {
-            return getTextErrorMessage(errorForm)
-        } else {
-            return getJsonErrorMessage(errorForm)
-        }
-    }
-
-    String getHtmlErrorMessage(Form errorForm) {
-        logger.debug("{}getHtmlErrorMessage, errorForm: '{}'", logPrefix,  errorForm)
-        StringBuilder errorMessageBuilder = new StringBuilder("<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Authorization Error" + 
-          "</title><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"></head><body>")
-        errorForm.forEach( (key, val) -> {
-            logger.debug("{}processing entry for {}, val is {}", logPrefix, key, val)
-            errorMessageBuilder.append("<p><b>" + key + ":</b> ")
-            List<String> values = val
-            Boolean first = true
-            values.forEach( (innerVal) -> {
-                logger.debug("{}adding value {} to error message", logPrefix, innerVal)
-                if(first){
-                    first = false
-                } else {
-                    errorMessageBuilder.append(', ')
-                }
-                errorMessageBuilder.append(innerVal)
-            })
-            errorMessageBuilder.append('</p>')
-        } )
-        errorMessageBuilder.append("</body></html>")
-        String htmlErrorMessage =  errorMessageBuilder.toString()
-        logger.debug("{}html error message is {}", logPrefix, htmlErrorMessage)
-        return htmlErrorMessage
-    }
-
-    String getJsonErrorMessage(Form errorForm){
-        logger.debug("{}getJsonErrorMessage, errorForm: '{}'", logPrefix, errorForm)
-        String jsonErrorMessage = new String(Json.writeJson(errorForm))
-        logger.debug("{}html error message is {}", logPrefix, jsonErrorMessage)
-        return jsonErrorMessage
-    }
-
-    String getTextErrorMessage(Form errorForm) {
-        logger.debug("{}getTextErrorMessage, errorForm: '{}'", logPrefix, errorForm)
-        StringBuilder errorMessageBuilder = new StringBuilder()
-        errorForm.forEach( (key, val) -> {
-            logger.debug("{}processing entry for {}, val is {}", logPrefix, key, val)
-            errorMessageBuilder.append(key + ": ")
-            List<String> values = val
-            Boolean first = true
-            values.forEach( (innerVal) -> {
-                logger.debug("{}adding value {} to error message", logPrefix, innerVal)
-                if(!first){
-                    errorMessageBuilder.append(', ')
-                }
-                errorMessageBuilder.append(innerVal)
-                first = false
-            })
-            errorMessageBuilder.append('\n')
-        } )
-        String textErrorMessage =  errorMessageBuilder.toString()
-        logger.debug("{}text error message is {}", logPrefix, textErrorMessage)
-        return textErrorMessage
-    }
-
-    String getFormUrlEncodedErrorMessage(Form errorForm) {
-        logger.debug("{}getFormUrlEncodedErrorMessage, errorForm: '{}'", logPrefix, errorForm)
-        String formUrlEncodedErrorMessage =  errorForm.toQueryString()
-        logger.debug("{}form URL encoded error message is {}", logPrefix, formUrlEncodedErrorMessage)
-        return formUrlEncodedErrorMessage
+        ContentTypeFormatter formatter = messageFormatterFactory.getContentTypeFormatter(bestContentType, logPrefix)
+        return formatter.getFormattedResponse(errorForm)
     }
 }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/ContentTypeNegotiator.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/ContentTypeNegotiator.groovy
@@ -1,0 +1,74 @@
+package com.forgerock.sapi.gateway.rest
+
+import org.forgerock.http.util.MultiValueMap
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * Class to help determine a suitable media type to return
+ */
+public class ContentTypeNegotiator {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass())
+
+    private final String logPrefix
+
+    private TreeMap<Float, List<String>> mediaTypesMap = [:]
+
+    private List<String> supportedContentTypes;
+
+    public ContentTypeNegotiator(String logPrefix, List<String> supportedContentTypes) {
+        this.logPrefix = logPrefix
+        this.supportedContentTypes = supportedContentTypes
+    }
+
+    /**
+     * Process the accepte header against a list of media types supported for the response
+     * returns a string representing the supported media type that best meets the media 
+     * types accepted by the client
+     */
+    String getBestContentType(Header acceptHeader) {
+        logger.debug('{}accept header contains {}', logPrefix, acceptHeader)
+
+        buildMapOfAcceptableMediaTypes(acceptHeader)
+        String bestContentType = findHighestWeightedSupportedMediaType()
+        logger.debug("{}Best Content Type is {}", logPrefix, bestContentType)
+        return bestContentType
+    }
+
+    private void buildMapOfAcceptableMediaTypes(Header acceptHeader) {
+        MultiValueMap<Float, List<String>> sortedContentTypes = new MultiValueMap(mediaTypesMap)
+        String[] acceptValues = acceptHeader.getValues()
+        for (String acceptValue in acceptValues) {
+            String[] contentTypes = acceptValue.split(',')
+            for (String contentType in contentTypes) {
+                String[] contentTypeAndQ = contentType.split(';')
+                if (contentTypeAndQ.size() == 1) {
+                    Float defaultWeight = 1.0f
+                    sortedContentTypes.add( defaultWeight , contentTypeAndQ[0].trim().toLowerCase())
+                } else if (contentTypeAndQ.size() == 2){
+                    String qValueStr = contentTypeAndQ[1].replace('q=', '')
+                    Float qValue = Float.valueOf(qValueStr).floatValue()
+                    sortedContentTypes.add(qValue, contentTypeAndQ[0].trim().toLowerCase())
+                } else {
+                    logger.debug('{}Invalid content type entry found in Accept header {}', logPrefix, acceptHeader)
+                }
+            }
+        }
+    }
+
+    private String findHighestWeightedSupportedMediaType() {
+        def reverseSortedContentTypes = mediaTypesMap.descendingMap()
+        for (content in reverseSortedContentTypes){
+            List<String> values = content.value
+            logger.debug('{}{} weighting is {}', logPrefix, values, content.key)
+            List matchingContentTypes = values.intersect(supportedContentTypes)
+            if (!matchingContentTypes.isEmpty()) {
+                logger.debug('{}Found matching content types {}', logPrefix, matchingContentTypes)
+                return matchingContentTypes[0]
+            }
+        }
+        logger.info('{}No matching media types', logPrefix)
+        return ''
+    }
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/HttpHeaderNames.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/HttpHeaderNames.groovy
@@ -1,0 +1,9 @@
+package com.forgerock.sapi.gateway.rest
+
+/**
+ * Class containing static strings specifying different Http media types
+*/
+public class HttpHeaderNames {
+    static final String X_FAPI_INTERACTION_ID = 'x-fapi-interaction-id'
+
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/HttpMediaTypes.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/HttpMediaTypes.groovy
@@ -1,0 +1,14 @@
+package com.forgerock.sapi.gateway.rest
+
+/**
+ * Class containing static strings specifying different Http media types
+*/
+public class HttpMediaTypes {
+
+    static final String TEXT_HTML = 'text/html'
+    static final String APPLICATION_TEXT = 'application/text'
+    static final String APPLICATION_JSON = 'application/json'
+    static final String APPLICATION_FORM_URLENCODED = 'application/x-www-form-urlencoded'
+    static final String ALL_TYPES = '*/*'
+
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/HttpRequestParameterNames.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/HttpRequestParameterNames.groovy
@@ -1,0 +1,9 @@
+package com.forgerock.sapi.gateway.rest
+
+/**
+ * Class containing static strings that define query parameter names 
+ */
+public class HttpRequestParameterNames {
+
+    static final String REQUEST = 'request'
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/content/ContentTypeFormatter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/content/ContentTypeFormatter.groovy
@@ -1,0 +1,5 @@
+package com.forgerock.sapi.gateway.rest.content
+
+interface ContentTypeFormatter {
+    String getFormattedResponse(Form errorForm)
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/content/ContentTypeFormatterFactory.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/content/ContentTypeFormatterFactory.groovy
@@ -1,0 +1,17 @@
+package com.forgerock.sapi.gateway.rest.content
+
+import com.forgerock.sapi.gateway.rest.HttpMediaTypes
+
+class ContentTypeFormatterFactory{
+    ContentTypeFormatter getContentTypeFormatter(String httpMediaType, String logPrefix){
+        if(httpMediaType == HttpMediaTypes.TEXT_HTML) {
+            return new ContentTypeFormatterHtml(logPrefix)
+        } else if (httpMediaType == HttpMediaTypes.APPLICATION_FORM_URLENCODED) {
+            return new ContentTypeFormatterFormUrlEncoded(logPrefix)
+        } else if (httpMediaType == HttpMediaTypes.APPLICATION_TEXT) {
+            return new ContentTypeFormatterText(logPrefix)
+        } else {
+            return new ContentTypeFormatterJson(logPrefix)
+        }
+    }
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/content/ContentTypeFormatterFormUrlEncoded.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/content/ContentTypeFormatterFormUrlEncoded.groovy
@@ -1,0 +1,21 @@
+package com.forgerock.sapi.gateway.rest.content
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class ContentTypeFormatterFormUrlEncoded implements ContentTypeFormatter {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass())
+    private final String logPrefix
+
+    public ContentTypeFormatterFormUrlEncoded(String logPrefix) {
+        this.logPrefix = logPrefix
+    }
+
+    String getFormattedResponse(Form errorForm) {
+        logger.debug("{}getFormUrlEncodedErrorMessage, errorForm: '{}'", logPrefix, errorForm)
+        String formUrlEncodedErrorMessage = errorForm.toQueryString()
+        logger.debug("{}form URL encoded error message is {}", logPrefix, formUrlEncodedErrorMessage)
+        return formUrlEncodedErrorMessage
+    }
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/content/ContentTypeFormatterHtml.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/content/ContentTypeFormatterHtml.groovy
@@ -1,0 +1,41 @@
+package com.forgerock.sapi.gateway.rest.content
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class ContentTypeFormatterHtml implements ContentTypeFormatter {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass())
+    private final String logPrefix
+
+    public ContentTypeFormatterHtml(String logPrefix) {
+        this.logPrefix = logPrefix
+    }
+
+    String getFormattedResponse(Form errorForm) {
+        logger.debug("{}getHtmlErrorMessage, errorForm: '{}'", logPrefix, errorForm)
+        StringBuilder errorMessageBuilder = new StringBuilder("<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Authorization Error" +
+                "</title><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"></head><body>")
+        errorForm.forEach((key, val) -> {
+            logger.debug("{}processing entry for {}, val is {}", logPrefix, key, val)
+            errorMessageBuilder.append("<p><b>" + key + ":</b> ")
+            List<String> values = val
+
+            Boolean first = true
+            values.forEach((innerVal) -> {
+                logger.debug("{}adding value {} to error message", logPrefix, innerVal)
+                if (first) {
+                    first = false
+                } else {
+                    errorMessageBuilder.append(', ')
+                }
+                errorMessageBuilder.append(innerVal)
+            })
+            errorMessageBuilder.append('</p>')
+        })
+        errorMessageBuilder.append("</body></html>")
+        String htmlErrorMessage = errorMessageBuilder.toString()
+        logger.debug("{}html error message is {}", logPrefix, htmlErrorMessage)
+        return htmlErrorMessage
+    }
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/content/ContentTypeFormatterJson.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/content/ContentTypeFormatterJson.groovy
@@ -1,0 +1,22 @@
+package com.forgerock.sapi.gateway.rest.content
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.forgerock.http.util.Json
+
+class ContentTypeFormatterJson implements ContentTypeFormatter {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass())
+    private final String logPrefix
+
+    public ContentTypeFormatterJson(String logPrefix) {
+        this.logPrefix = logPrefix
+    }
+
+    String getFormattedResponse(Form errorForm) {
+        logger.debug("{}getJsonErrorMessage, errorForm: '{}'", logPrefix, errorForm)
+        String jsonErrorMessage = new String(Json.writeJson(errorForm))
+        logger.debug("{}html error message is {}", logPrefix, jsonErrorMessage)
+        return jsonErrorMessage
+    }
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/content/ContentTypeFormatterText.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/content/ContentTypeFormatterText.groovy
@@ -1,0 +1,37 @@
+package com.forgerock.sapi.gateway.rest.content
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class ContentTypeFormatterText implements ContentTypeFormatter {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass())
+    private final String logPrefix
+
+    ContentTypeFormatterText(String logPrefix) {
+        this.logPrefix = logPrefix
+    }
+
+    String getFormattedResponse(Form errorForm) {
+        logger.debug("{}getTextErrorMessage, errorForm: '{}'", logPrefix, errorForm)
+        StringBuilder errorMessageBuilder = new StringBuilder()
+        errorForm.forEach((key, val) -> {
+            logger.debug("{}processing entry for {}, val is {}", logPrefix, key, val)
+            errorMessageBuilder.append(key + ": ")
+            List<String> values = val
+            Boolean first = true
+            values.forEach((innerVal) -> {
+                logger.debug("{}adding value {} to error message", logPrefix, innerVal)
+                if (!first) {
+                    errorMessageBuilder.append(', ')
+                }
+                errorMessageBuilder.append(innerVal)
+                first = false
+            })
+            errorMessageBuilder.append('\n')
+        })
+        String textErrorMessage = errorMessageBuilder.toString()
+        logger.debug("{}text error message is {}", logPrefix, textErrorMessage)
+        return textErrorMessage
+    }
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/content/ContentTypeNegotiator.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/rest/content/ContentTypeNegotiator.groovy
@@ -1,4 +1,4 @@
-package com.forgerock.sapi.gateway.rest
+package com.forgerock.sapi.gateway.rest.content
 
 import org.forgerock.http.util.MultiValueMap
 import org.slf4j.Logger


### PR DESCRIPTION
Fixes for failures when running the fapi1-advanced-final conformance suite tests.

There are some issues with the validation of our request object

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/676