### PR TITLE
678: Adding route which matches calls to the AM XUI and  disabling message capture for this route

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -65,6 +65,10 @@
       ]
     },
     {
+      "name": "ReverseProxyHandlerNoCapture",
+      "type": "ReverseProxyHandler"
+    },
+    {
       "name": "JwtSession",
       "type": "JwtSession"
     },
@@ -106,10 +110,6 @@
       "name": "SBATReverseProxyHandlerIdentityPlatform",
       "comment": "ReverseProxyHandler for calls to Identity Platform services (AM or IDM)",
       "type": "Chain",
-      "capture": [
-        "request",
-        "response"
-      ],
       "config": {
         "filters" : [ 
           "TransactionIdOutboundFilter"
@@ -118,13 +118,20 @@
       }
     },
     {
+      "name": "SBATReverseProxyHandlerIdentityPlatformNoCapture",
+      "comment": "ReverseProxyHandler for calls to Identity Platform services (AM or IDM), capture decorator disabled",
+      "type": "Chain",
+      "config": {
+        "filters" : [
+          "TransactionIdOutboundFilter"
+        ],
+        "handler" : "ReverseProxyHandlerNoCapture"
+      }
+    },
+    {
       "name": "SBATReverseProxyHandlerRs",
       "comment": "ReverseProxyHandler for calls to the SBAT RS",
       "type": "Chain",
-      "capture": [
-        "request",
-        "response"
-      ],
       "config": {
         "filters": [
           {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/90-ob-as-xui.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/90-ob-as-xui.json
@@ -1,0 +1,33 @@
+{
+  "comment": "AM XUI routes, access the AM XUI and turns off captures to avoid IG logs being spammed with UI resources",
+  "name": "98 - AM XUI Access",
+  "auditService": "AuditService-OB-Route",
+  "baseURI": "https://&{identity.platform.fqdn}",
+  "condition": "${matches(request.uri.path, '^/am/XUI/.*')}",
+  "handler": {
+    "type": "Chain",
+    "config": {
+      "filters": [
+        "SBATFapiInteractionFilterChain",
+        {
+          "comment": "Add host header to downstream request",
+          "name": "HeaderFilter-ChangeHostToIAM",
+          "type": "HeaderFilter",
+          "config": {
+            "messageType": "REQUEST",
+            "remove": [
+              "host",
+              "X-Forwarded-Host"
+            ],
+            "add": {
+              "X-Forwarded-Host": [
+                "&{ig.fqdn}"
+              ]
+            }
+          }
+        }
+      ],
+      "handler": "SBATReverseProxyHandlerIdentityPlatformNoCapture"
+    }
+  }
+}


### PR DESCRIPTION
Disabling capturing messages for calls to the AM XUI. Previously, all AM XUI resources were being captured in the IG logs i.e. all HTML pages, js and css file contents.

Adding new handlers: SBATReverseProxyHandlerIdentityPlatformNoCapture and ReverseProxyHandlerNoCapture which handle reverse proxying without capturing.

Fixing bug where SBATReverseProxyHandlerIdentityPlatform and SBATReverseProxyHandlerRs handlers were capturing messages twice as they configured a capture and so did the underlying ReverseProxyHandler which both delegate to.

https://github.com/SecureApiGateway/SecureApiGateway/issues/678