### PR TITLE
694: Support tls_client_auth

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -4,7 +4,7 @@
       "allowIgIssuedTestCerts": true
     },
     "oauth2": {
-      "tokenEndpointAuthMethodsSupported": ["private_key_jwt"]
+      "tokenEndpointAuthMethodsSupported": ["private_key_jwt", "tls_client_auth"]
     }
   },
   "handler": "_router",

--- a/config/7.1.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/prod/config/config.json
@@ -4,7 +4,7 @@
       "allowIgIssuedTestCerts": false
     },
     "oauth2": {
-      "tokenEndpointAuthMethodsSupported": ["private_key_jwt"]
+      "tokenEndpointAuthMethodsSupported": ["private_key_jwt", "tls_client_auth"]
     }
   },
   "handler": {

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -76,6 +76,9 @@ switch(method.toUpperCase()) {
         if (!tokenEndpointAuthMethod || !tokenEndpointAuthMethodsSupported.contains(tokenEndpointAuthMethod)) {
             return errorResponseFactory.invalidClientMetadataErrorResponse("token_endpoint_auth_method claim must be one of: " + tokenEndpointAuthMethodsSupported)
         }
+        if (tokenEndpointAuthMethod.equals("tls_client_auth") && !oidcRegistration.getClaim("tls_client_auth_subject_dn")) {
+            return errorResponseFactory.invalidClientMetadataErrorResponse("tls_client_auth_subject_dn must be provided to use tls_client_auth")
+        }
 
         def ssa = oidcRegistration.getClaim("software_statement", String.class);
         if (!ssa) {
@@ -194,8 +197,6 @@ switch(method.toUpperCase()) {
         if (oiComponents.length > 3) {
             return errorResponseFactory.invalidClientMetadataErrorResponse("Wrong number of dashes in OI " + organizationalIdentifier +" - expected 2")
         }
-
-        // TODO: Subject DN for cert bound access tokens
 
         // Convert to JSON and pass it on
         def regJson = oidcRegistration.build();


### PR DESCRIPTION
- Adding tls_client_auth to config: oauth2.tokenEndpointAuthMethodsSupported
- Adding validation in ProcessRegistration to check that tls_client_auth_subject_dn is supplied when using tls_client_auth

https://github.com/SecureApiGateway/SecureApiGateway/issues/699