### PR TITLE
678: Disabling message capture for IG route 99

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -65,6 +65,11 @@
       ]
     },
     {
+      "name": "ReverseProxyHandlerNoCapture",
+      "type": "ReverseProxyHandler",
+      "comment": "ReverseProxyHandler with no capture decorator configuration"
+    },
+    {
       "name": "JwtSession",
       "type": "JwtSession"
     },
@@ -106,10 +111,6 @@
       "name": "SBATReverseProxyHandlerIdentityPlatform",
       "comment": "ReverseProxyHandler for calls to Identity Platform services (AM or IDM)",
       "type": "Chain",
-      "capture": [
-        "request",
-        "response"
-      ],
       "config": {
         "filters" : [ 
           "TransactionIdOutboundFilter"
@@ -118,13 +119,20 @@
       }
     },
     {
+      "name": "SBATReverseProxyHandlerIdentityPlatformNoCapture",
+      "comment": "ReverseProxyHandler for calls to Identity Platform services (AM or IDM), with the capture decorator disabled",
+      "type": "Chain",
+      "config": {
+        "filters" : [
+          "TransactionIdOutboundFilter"
+        ],
+        "handler" : "ReverseProxyHandlerNoCapture"
+      }
+    },
+    {
       "name": "SBATReverseProxyHandlerRs",
       "comment": "ReverseProxyHandler for calls to the SBAT RS",
       "type": "Chain",
-      "capture": [
-        "request",
-        "response"
-      ],
       "config": {
         "filters": [
           {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/99-ob-as.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/99-ob-as.json
@@ -1,5 +1,5 @@
 {
-  "comment": "Passthrough for any unprotected AM endpoints",
+  "comment": "Passthrough for any unprotected AM endpoints (such as the XUI)",
   "name": "99 - OBIE AS General",
   "auditService": "AuditService-OB-Route",
   "baseURI": "https://&{identity.platform.fqdn}",
@@ -27,7 +27,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerIdentityPlatform"
+      "handler": "SBATReverseProxyHandlerIdentityPlatformNoCapture"
     }
   }
 }


### PR DESCRIPTION
Route 99 is the "pass through" route for AM access which does not have a more specific route. This includes accessing the XUI.

Adding new handler SBATReverseProxyHandlerIdentityPlatformNoCapture and using it in route 99 in order to stop capturing these messages in the logs. Access to the XUI includes all calls to fetch html/css/js resources and if capturing is enabled this floods the logs.

Also fixing a bug with the SBATReverseProxyHandlerIdentityPlatform and SBATReverseProxyHandlerRs handlers which were logging captures twice, this is due to them have capturing enabled and the underlying ReverseProxyHandler also having capturing enabled.

If we find that there are other flows which are hitting route 99, and if we deem them important enough to have message capturing, then we can add a route for that specific use case with capturing enabled. Previously, calls to the /authorize endpoint would have fit route 99, but after https://github.com/SecureApiGateway/securebanking-openbanking-uk-gateway/pull/248 was merged they have their own dedicated route.

https://github.com/SecureApiGateway/SecureApiGateway/issues/678