### PR TITLE
304: Increase vertx maxHeaderSize and maxHeaderListSize properties to 16k

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -5,6 +5,12 @@
     },
     "oauth2": {
       "tokenEndpointAuthMethodsSupported": ["private_key_jwt"]
+    },
+    "vertxConfig": {
+      "maxHeaderSize": 16384,
+      "initialSettings": {
+        "maxHeaderListSize": 16384
+      }
     }
   },
   "handler": "_router",
@@ -62,12 +68,18 @@
       "capture": [
         "request",
         "response"
-      ]
+      ],
+      "config": {
+        "vertx": "${vertxConfig}"
+      }
     },
     {
       "name": "ReverseProxyHandlerNoCapture",
       "type": "ReverseProxyHandler",
-      "comment": "ReverseProxyHandler with no capture decorator configuration"
+      "comment": "ReverseProxyHandler with no capture decorator configuration",
+      "config": {
+        "vertx": "${vertxConfig}"
+      }
     },
     {
       "name": "JwtSession",


### PR DESCRIPTION
When reverse proxying AM, the /authorize call is returning header list size > 8k (the default max size). This causes an exception to be thrown in IG, due to it being unable to decode the HTTP frame.

Example exception:
```
Caused by: io.netty.handler.codec.http2.Http2Exception$HeaderListSizeException: Header size exceeded max allowed size (8192)
	at io.netty.handler.codec.http2.Http2Exception.headerListSizeError(Http2Exception.java:194)
	at io.netty.handler.codec.http2.Http2CodecUtil.headerListSizeExceeded(Http2CodecUtil.java:233)
	at io.netty.handler.codec.http2.HpackDecoder$Http2HeadersSink.finish(HpackDecoder.java:545)
	at io.netty.handler.codec.http2.HpackDecoder.decode(HpackDecoder.java:132)
	at io.netty.handler.codec.http2.DefaultHttp2HeadersDecoder.decodeHeaders(DefaultHttp2HeadersDecoder.java:126)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader$HeadersBlockBuilder.headers(DefaultHttp2FrameReader.java:743)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader$2.processFragment(DefaultHttp2FrameReader.java:483)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readHeadersFrame(DefaultHttp2FrameReader.java:491)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:254)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:160)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:181)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:63)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:378)
	... 34 common frames omitted
```

Supplying vertx configuration for our ReverseProxyHandler objects, and configuring maxHeaderSize/maxHeaderListSize as 16k

https://github.com/SecureApiGateway/SecureApiGateway/issues/304