### PR TITLE
728: Create heap service to provide trusted directory

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -402,9 +402,10 @@
     {
       "name": "TrustedDirectoriesService",
       "type": "TrustedDirectoriesService",
+      "comment": "Used to obtain meta information about a trusted directory by look up using the 'iss' field value",
       "config": {
         "enableIGTestTrustedDirectory": true,
-        "testDirectoryFQDN": "https://&{ig.fqdn}/jwkms/apiclient/jwks"
+        "SecureApiGatewayJwksUri": "https://&{ig.fqdn}/jwkms/apiclient/jwks"
       }
     },
     {

--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -400,6 +400,14 @@
       }
     },
     {
+      "name": "TrustedDirectoriesService",
+      "type": "TrustedDirectoriesService",
+      "config": {
+        "enableIGTestTrustedDirectory": true,
+        "testDirectoryFQDN": "https://&{ig.fqdn}/jwkms/apiclient/jwks"
+      }
+    },
+    {
       "name": "RsaJwtSignatureValidator",
       "type": "RsaJwtSignatureValidator"
     }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -81,7 +81,7 @@
                 "OpenBanking Ltd": "${urlDecode('https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks')}",
                 "test-publisher": "${urlDecode('https://&{ig.fqdn}/jwkms/apiclient/jwks')}"
               },
-              "trustedDirectoryService": "${heap['TrustedDirectoryService']}",
+              "trustedDirectoryService": "${heap['TrustedDirectoriesService']}",
               "jwtSignatureValidator": "${heap['RsaJwtSignatureValidator']}"
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -81,6 +81,7 @@
                 "OpenBanking Ltd": "${urlDecode('https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks')}",
                 "test-publisher": "${urlDecode('https://&{ig.fqdn}/jwkms/apiclient/jwks')}"
               },
+              "trustedDirectoryService": "${heap['TrustedDirectoryService']}",
               "jwtSignatureValidator": "${heap['RsaJwtSignatureValidator']}"
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -77,10 +77,6 @@
             "file": "SSAVerifier.groovy",
             "clientHandler": "OBClientHandler",
             "args": {
-              "routeArgSSAIssuerJwksUrls": {
-                "OpenBanking Ltd": "${urlDecode('https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks')}",
-                "test-publisher": "${urlDecode('https://&{ig.fqdn}/jwkms/apiclient/jwks')}"
-              },
               "trustedDirectoryService": "${heap['TrustedDirectoriesService']}",
               "jwtSignatureValidator": "${heap['RsaJwtSignatureValidator']}"
             }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
@@ -51,14 +51,14 @@ switch(method.toUpperCase()) {
         }
 
         TrustedDirectory trustedDirectory = trustedDirectoryService.getTrustedDirectoryConfiguration(ssaIssuer)
-
         if(trustedDirectory){
             logger.debug(SCRIPT_NAME + "Found trusted directory for issuer '" + ssaIssuer + "'")
         } else {
             logger.debug(SCRIPT_NAME + "Could not find Trusted Directory for issuer '" + ssaIssuer + "'")
+            return errorResponseFactory.invalidSoftwareStatementErrorResponse("issuer: " + ssaIssuer + " is not supported")
         }
 
-        def ssaJwksUrl = routeArgSSAIssuerJwksUrls[ssaIssuer]
+        def ssaJwksUrl = trustedDirectory.getJwksUri()
         if (!ssaJwksUrl) {
             return errorResponseFactory.invalidSoftwareStatementErrorResponse("issuer: " + ssaIssuer + " is not supported")
         }
@@ -75,7 +75,7 @@ switch(method.toUpperCase()) {
           def jwksResponseStatus = jwksResponse.getStatus()
 
           logger.debug(SCRIPT_NAME + "status " + jwksResponseStatus)
-          logger.debug(SCRIPT_NAME + "entity " + jwksResponseContent)
+          logger.debug(SCRIPT_NAME + "entity " + jwksResponseContent.replaceAll("[\\n\\t ]", ""))
 
           if (jwksResponseStatus != Status.OK) {
               return newResultPromise(errorResponseFactory.errorResponse(Status.UNAUTHORIZED, "Bad response from JWKS URI " + jwksResponseStatus))

--- a/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.security.SignatureException
 import com.securebanking.gateway.dcr.ErrorResponseFactory
 import static org.forgerock.util.promise.Promises.newResultPromise
+import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectory
 
 def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
 if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
@@ -41,6 +42,13 @@ switch(method.toUpperCase()) {
         def ssaIssuer = ssaClaims.getIssuer()
         if (!ssaIssuer) {
             return errorResponseFactory.invalidSoftwareStatementErrorResponse("issuer claim is required")
+        }
+
+        TrustedDirectory trustedDirectory = trustedDirectoryService.getTrustedDirectoryConfiguration(ssaIssuer)
+        if(trustedDirectory){
+            logger.debug(SCRIPT_NAME + "Found trusted directory for issuer '" + ssaIssuer + "'")
+        } else {
+            logger.debug(SCRIPT_NAME + "Could not find Trusted Directory for issuer '" + ssaIssuer + "'")
         }
 
         def ssaJwksUrl = routeArgSSAIssuerJwksUrls[ssaIssuer]

--- a/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
@@ -12,6 +12,12 @@ SCRIPT_NAME = "[SSAVerifier] (" + fapiInteractionId + ") - ";
 
 logger.debug(SCRIPT_NAME + "Running...")
 
+
+if(trustedDirectoryService == null) {
+    logger.error(SCRIPT_NAME + "No TrustedDirectoriesService defined on the heap in config.json")
+    return new Response(Status.INTERNAL_SERVER_ERROR).body("No TrustedDirectoriesService defined on the heap in config.json")
+}
+
 def verifySignature(signedJwt, jwksJson) {
     def jwks = JWKSet.parse(jwksJson);
     try {
@@ -45,6 +51,7 @@ switch(method.toUpperCase()) {
         }
 
         TrustedDirectory trustedDirectory = trustedDirectoryService.getTrustedDirectoryConfiguration(ssaIssuer)
+
         if(trustedDirectory){
             logger.debug(SCRIPT_NAME + "Found trusted directory for issuer '" + ssaIssuer + "'")
         } else {

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/jwt/JwtUtils.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/jwt/JwtUtils.groovy
@@ -1,0 +1,41 @@
+package com.forgerock.sapi.gateway.jwt
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.forgerock.json.jose.common.JwtReconstruction
+import org.forgerock.json.jose.jws.SignedJwt
+import org.forgerock.json.jose.jwt.JwtClaimsSet
+import org.forgerock.json.jose.jwt.Jwt
+
+
+class JwtUtils {
+
+    static private final Logger logger = LoggerFactory.getLogger(getClass())
+
+    static Jwt getSignedJwtFromString(String logPrefix, String jwtAsString, String jwtName){
+        logger.debug(logPrefix + "Parsing jwt {}", jwtName);
+        Jwt jwt
+        try {
+            jwt = new JwtReconstruction().reconstructJwt(jwtAsString, SignedJwt.class)
+        } catch (e) {
+            logger.warn(logPrefix + "failed to decode registration request JWT", e)
+            return null
+        }
+        return jwt
+    }
+
+    static JwtClaimsSet getClaimsFromSignedJwtAsString(String logPrefix, String jwtAsString, String jwtName){
+        Jwt jwt = getJwtFromString(logPrefix, jwtAsString, jwtName)
+        return jwt.getClaimsSet()
+    }
+
+    static boolean hasExpired(JwtClaimsSet claimSet){
+        Boolean hasExpired = false
+        Date expirationTime = claimSet.getExpirationTime()
+        if (expirationTime.before(new Date())) {
+            hasExpired = true
+        }
+        return hasExpired
+    }
+
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
@@ -24,6 +24,7 @@ import com.forgerock.sapi.gateway.fapi.v1.FAPIAdvancedDCRValidationFilter;
 import com.forgerock.sapi.gateway.jwks.RestJwkSetService;
 import com.forgerock.sapi.gateway.jwks.cache.caffeine.CaffeineCachingJwkSetService;
 import com.forgerock.sapi.gateway.jws.RsaJwtSignatureValidator;
+import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectoryService;
 
 public class SecureApiGatewayClassAliasResolver implements ClassAliasResolver {
     private static final Map<String, Class<?>> ALIASES = new HashMap<>();
@@ -33,6 +34,7 @@ public class SecureApiGatewayClassAliasResolver implements ClassAliasResolver {
         ALIASES.put("CaffeineCachingJwkSetService", CaffeineCachingJwkSetService.class);
         ALIASES.put("RestJwkSetService", RestJwkSetService.class);
         ALIASES.put("RsaJwtSignatureValidator", RsaJwtSignatureValidator.class);
+        ALIASES.put("TrustedDirectoriesService", TrustedDirectoryService.class);
     }
 
     /**

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
@@ -42,7 +42,7 @@ public interface TrustedDirectory {
      * software statement that holds the jwks_uri against which certificates associated with the software statement can
      * be found. If @link #softwareStatementHoldsJwksUri() returns false this will return null
      */
-    String getSoftwareStatementJwksUriClaimFName();
+    String getSoftwareStatementJwksUriClaimName();
 
 
     /**

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+public interface TrustedDirectory {
+    /**
+     * @return the value that can be expected to be found in the issuer field of Software Statements issued
+     * by the Trusted Directory
+     */
+    String getIssuer();
+
+    /**
+     *
+     * @return a String containing the jwks_uri against which software statement issued by this trusted directory
+     * can be validated
+     */
+    String getJwksUri();
+
+    /**
+     *
+     * @return true if the software statement contains the full JWKS entry - this is not recommended as it is brittle.
+     * Using a jwks_uri against which Certificates associated with Software Statement can be validated allows for
+     * key rotation
+     */
+    Boolean softwareStatementHoldsJwksUri();
+    /**
+     *
+     * @return If @link #softwareStatementHoldsJwksUri() returns true this method will return the name of the claim in the
+     * software statement that holds the jwks_uri against which certificates associated with the software statement can
+     * be found. If @link #softwareStatementHoldsJwksUri() returns false this will return null
+     */
+    String getSoftwareStatementJwksUriClaimFName();
+
+
+    /**
+     * If @link #softwareStatementHoldsJwksUri() returns false this method will return the name of the Software Statement
+     * claim in which the JWKS entry maybe found. If it returns true, this method will return null
+     */
+    String getSoftwareStatementJwksClaimName();
+
+    /**
+     *
+     * @return the name of the claim in the software statement that holds a unique identifier for the organisation
+     * to which the Software Statement belongs
+     */
+    String getSoftwareStatementOrgIdClaimName();
+
+    /**
+     *
+     * @return the name of the claim in the software statement that holds a unique identifier for the software statement
+     */
+    String getSoftwareStatementSoftwareIdClaimName();
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
@@ -15,6 +15,17 @@
  */
 package com.forgerock.sapi.gateway.trusteddirectories;
 
+/**
+ * A Trusted Directory is an external 'trust anchor' that the Secure API Gateway should trust to be the issuer
+ * of software statements and the certificates associated with those statements. This interface allows access to
+ * configuration information for a trusted directory. In the UK this is the Open Banking Directory, or the Open Banking
+ * Sandbox Directory. It is trusted by both the ApiClient and the ApiProvider. In other eco-systems the registry will
+ * be different. In some cases it can be a registry provided by the ApiProvider. For example a bank wishing to provide
+ * innovative new custom APIs outside of a regulated system could create their own Trusted Registry.
+ *
+ * @see <a href="https://github.com/SecureApiGateway/SecureApiGateway/wiki/About-Dynamic-Client-Registration">
+ *     About Dynamic Client Registration</a>
+ */
 public interface TrustedDirectory {
     /**
      * @return the value that can be expected to be found in the issuer field of Software Statements issued
@@ -35,7 +46,7 @@ public interface TrustedDirectory {
      * Using a jwks_uri against which Certificates associated with Software Statement can be validated allows for
      * key rotation
      */
-    Boolean softwareStatementHoldsJwksUri();
+    boolean softwareStatementHoldsJwksUri();
     /**
      *
      * @return If @link #softwareStatementHoldsJwksUri() returns true this method will return the name of the claim in the

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
@@ -24,7 +24,7 @@ public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
     final static String issuer = "OpenBanking Ltd";
 
 
-    final static Boolean softwareStatementHoldsJwksUri = true;
+    final static boolean softwareStatementHoldsJwksUri = true;
 
     /*
      * The URL at which the Open Banking Test Directory JWKS are held, containing public certificates that may be used
@@ -59,7 +59,7 @@ public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
     }
 
     @Override
-    public Boolean softwareStatementHoldsJwksUri() {
+    public boolean softwareStatementHoldsJwksUri() {
         return softwareStatementHoldsJwksUri;
     }
 

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
@@ -64,7 +64,7 @@ public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
     }
 
     @Override
-    public String getSoftwareStatementJwksUriClaimFName() {
+    public String getSoftwareStatementJwksUriClaimName() {
         return softwareJwksUriClaimName;
     }
 

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
+
+    /*
+     * The value expected to be found in the issuer field of software statements issued by the Open Banking Test
+     * directory
+     */
+    final static String issuer = "OpenBanking Ltd";
+
+
+    final static Boolean softwareStatementHoldsJwksUri = true;
+
+    /*
+     * The URL at which the Open Banking Test Directory JWKS are held, containing public certificates that may be used
+     * to validate Open Banking Test directory issues Software Statements.
+     */
+    final static String jwksUri = "https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks";
+
+    /*
+     * The name of the claim in the Open Banking Test Directory issued software statement that holds the jwks_uri
+     * against which certificates associated with this software statement may be validated
+     */
+    final static String softwareJwksEndpointClaimName = "software_jwks_endpoint";
+    /*
+     * The name of the claim in the Open Banking Test Directory issued software statement that holds a uid for the
+     * organisation
+     */
+    final static String softwareStatementOrgIdClaimName = "org_id";
+    /*
+     * The name of the claim in the Open Banking Test Directory issued software statement that holds a uid for the
+     * software statement
+     */
+    final static String softwareStatementSoftwareIdClaimName = "software_id";
+
+    @Override
+    public String getIssuer() {
+        return issuer;
+    }
+
+    @Override
+    public String getJwksUri() {
+        return jwksUri;
+    }
+
+    @Override
+    public Boolean softwareStatementHoldsJwksUri() {
+        return softwareStatementHoldsJwksUri;
+    }
+
+    @Override
+    public String getSoftwareStatementJwksUriClaimFName() {
+        return softwareJwksEndpointClaimName;
+    }
+
+    @Override
+    public String getSoftwareStatementJwksClaimName() {
+        return null;
+    }
+
+    @Override
+    public String getSoftwareStatementOrgIdClaimName() {
+        return softwareStatementOrgIdClaimName;
+    }
+
+    @Override
+    public String getSoftwareStatementSoftwareIdClaimName() {
+        return softwareStatementSoftwareIdClaimName;
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
@@ -36,7 +36,7 @@ public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
      * The name of the claim in the Open Banking Test Directory issued software statement that holds the jwks_uri
      * against which certificates associated with this software statement may be validated
      */
-    final static String softwareJwksEndpointClaimName = "software_jwks_endpoint";
+    final static String softwareJwksUriClaimName = "software_jwks_endpoint";
     /*
      * The name of the claim in the Open Banking Test Directory issued software statement that holds a uid for the
      * organisation
@@ -65,7 +65,7 @@ public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
 
     @Override
     public String getSoftwareStatementJwksUriClaimFName() {
-        return softwareJwksEndpointClaimName;
+        return softwareJwksUriClaimName;
     }
 
     @Override

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
@@ -65,7 +65,7 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
     }
 
     @Override
-    public String getSoftwareStatementJwksUriClaimFName() {
+    public String getSoftwareStatementJwksUriClaimName() {
         return null;
     }
 

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
@@ -15,6 +15,11 @@
  */
 package com.forgerock.sapi.gateway.trusteddirectories;
 
+/**
+ * Holds static configuration information for the Trusted Directory provided by the Secure API Gateway itself. For
+ * development and test purposes it is useful to be able to use the Secure API Gateway to issue SSAs and Certificates
+ * associated with the SSA itself.
+ */
 public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
 
     /*
@@ -27,9 +32,9 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
      * The URL at which the Open Banking Test Directory JWKS are held, containing public certificates that may be used
      * to validate Open Banking Test directory issues Software Statements.
      */
-    String jwksUri = null;
+    String secureApiGatewayJwksUri = null;
 
-    final static Boolean softwareStatementHoldsJwksUri = false;
+    final static boolean softwareStatementHoldsJwksUri = false;
 
     final static String softwareStatementJwksClaimName = "software_jwks";
 
@@ -44,9 +49,13 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
      */
     final static String softwareStatementSoftwareIdClaimName = "software_client_id";
 
-    public TrustedDirectorySecureApiGateway(String testDirectoryFQDN){
-        super();
-        this.jwksUri = testDirectoryFQDN;
+    /**
+     * Constructor
+     * @param secureApiGatewayJwksUri The jwks_uri against which SSAs issued by the Secure API Gateway can be
+     *                                validated
+     */
+    public TrustedDirectorySecureApiGateway(String secureApiGatewayJwksUri){
+        this.secureApiGatewayJwksUri = secureApiGatewayJwksUri;
     }
 
     @Override
@@ -56,11 +65,11 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
 
     @Override
     public String getJwksUri() {
-        return this.jwksUri;
+        return this.secureApiGatewayJwksUri;
     }
 
     @Override
-    public Boolean softwareStatementHoldsJwksUri() {
+    public boolean softwareStatementHoldsJwksUri() {
         return softwareStatementHoldsJwksUri;
     }
 

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
@@ -23,21 +23,16 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
      */
     final static String issuer = "test-publisher";
 
-    final static Boolean softwareStatementHoldsJwksUri = false;
-
-    final static String softwareStatementJwksClaimName = "software_jwks";
-
     /*
      * The URL at which the Open Banking Test Directory JWKS are held, containing public certificates that may be used
      * to validate Open Banking Test directory issues Software Statements.
      */
     String jwksUri = null;
 
-    /*
-     * The name of the claim in the Open Banking Test Directory issued software statement that holds the jwks_uri
-     * against which certificates associated with this software statement may be validated
-     */
-    final static String softwareJwksEndpointClaimName = "software_jwks_endpoint";
+    final static Boolean softwareStatementHoldsJwksUri = false;
+
+    final static String softwareStatementJwksClaimName = "software_jwks";
+
     /*
      * The name of the claim in the Open Banking Test Directory issued software statement that holds a uid for the
      * organisation
@@ -61,12 +56,12 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
 
     @Override
     public String getJwksUri() {
-        return null;
+        return this.jwksUri;
     }
 
     @Override
     public Boolean softwareStatementHoldsJwksUri() {
-        return null;
+        return softwareStatementHoldsJwksUri;
     }
 
     @Override
@@ -76,16 +71,16 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
 
     @Override
     public String getSoftwareStatementJwksClaimName() {
-        return null;
+        return softwareStatementJwksClaimName;
     }
 
     @Override
     public String getSoftwareStatementOrgIdClaimName() {
-        return null;
+        return softwareStatementOrgIdClaimName;
     }
 
     @Override
     public String getSoftwareStatementSoftwareIdClaimName() {
-        return null;
+        return softwareStatementSoftwareIdClaimName;
     }
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
+
+    /*
+     * The value expected to be found in the issuer field of software statements issued by the Open Banking Test
+     * directory
+     */
+    final static String issuer = "test-publisher";
+
+    final static Boolean softwareStatementHoldsJwksUri = false;
+
+    final static String softwareStatementJwksClaimName = "software_jwks";
+
+    /*
+     * The URL at which the Open Banking Test Directory JWKS are held, containing public certificates that may be used
+     * to validate Open Banking Test directory issues Software Statements.
+     */
+    String jwksUri = null;
+
+    /*
+     * The name of the claim in the Open Banking Test Directory issued software statement that holds the jwks_uri
+     * against which certificates associated with this software statement may be validated
+     */
+    final static String softwareJwksEndpointClaimName = "software_jwks_endpoint";
+    /*
+     * The name of the claim in the Open Banking Test Directory issued software statement that holds a uid for the
+     * organisation
+     */
+    final static String softwareStatementOrgIdClaimName = "org_id";
+    /*
+     * The name of the claim in the Open Banking Test Directory issued software statement that holds a uid for the
+     * software statement
+     */
+    final static String softwareStatementSoftwareIdClaimName = "software_client_id";
+
+    public TrustedDirectorySecureApiGateway(String testDirectoryFQDN){
+        super();
+        this.jwksUri = testDirectoryFQDN;
+    }
+
+    @Override
+    public String getIssuer() {
+        return issuer;
+    }
+
+    @Override
+    public String getJwksUri() {
+        return null;
+    }
+
+    @Override
+    public Boolean softwareStatementHoldsJwksUri() {
+        return null;
+    }
+
+    @Override
+    public String getSoftwareStatementJwksUriClaimFName() {
+        return null;
+    }
+
+    @Override
+    public String getSoftwareStatementJwksClaimName() {
+        return null;
+    }
+
+    @Override
+    public String getSoftwareStatementOrgIdClaimName() {
+        return null;
+    }
+
+    @Override
+    public String getSoftwareStatementSoftwareIdClaimName() {
+        return null;
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryService.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryService.java
@@ -16,5 +16,6 @@
 package com.forgerock.sapi.gateway.trusteddirectories;
 
 public interface TrustedDirectoryService {
+
     TrustedDirectory getTrustedDirectoryConfiguration(String issuer);
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryService.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryService.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+public interface TrustedDirectoryService {
+    TrustedDirectory getTrustedDirectoryConfiguration(String issuer);
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceHeaplet.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceHeaplet.java
@@ -41,14 +41,14 @@ public class TrustedDirectoryServiceHeaplet extends GenericHeaplet {
                 .as(evaluatedWithHeapProperties())
                 .defaultTo(DEFAULT_IG_TEST_DIRECTORY_ENABLED)
                 .asBoolean();
-        final String testDirectoryFQDN = config.get("testDirectoryFQDN")
+        final String secureApiGatewayJwksUri = config.get("SecureApiGatewayJwksUri")
                 .as(evaluatedWithHeapProperties())
                 .defaultTo(null)
                 .asString();
 
 
-        logger.debug("Creating Trusted Directory Service with enableIGTestTrustedDirectory: {}, testDirectoryFQDN: {}",
-                enableIGTestTrustedDirectory, testDirectoryFQDN);
-        return new TrustedDirectoryServiceStatic(enableIGTestTrustedDirectory, testDirectoryFQDN);
+        logger.debug("Creating Trusted Directory Service with enableIGTestTrustedDirectory: {}, secureApiGatewayJwksUri: {}",
+                enableIGTestTrustedDirectory, secureApiGatewayJwksUri);
+        return new TrustedDirectoryServiceStatic(enableIGTestTrustedDirectory, secureApiGatewayJwksUri);
     }
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceHeaplet.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceHeaplet.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+import static org.forgerock.openig.util.JsonValues.javaDuration;
+
+import java.time.Duration;
+
+import org.forgerock.openig.heap.GenericHeaplet;
+import org.forgerock.openig.heap.HeapException;
+
+import com.forgerock.sapi.gateway.jwks.cache.caffeine.CaffeineCache;
+
+public class TrustedDirectoryServiceHeaplet extends GenericHeaplet {
+
+    private final Boolean DEFAULT_IG_TEST_DIRECTORY_ENABLED = false;
+
+    @Override
+    public Object create() throws HeapException {
+        return createTrustedDirectoryService();
+    }
+
+    private Object createTrustedDirectoryService() {
+        final Boolean enableIGTestTrustedDirectory = config.get("enableIGTestTrustedDirectory")
+                .as(evaluatedWithHeapProperties())
+                .defaultTo(DEFAULT_IG_TEST_DIRECTORY_ENABLED)
+                .asBoolean();
+        final String testDirectoryFQDN = config.get("testDirectoryFQDN")
+                .as(evaluatedWithHeapProperties())
+                .defaultTo(null)
+                .asString();
+
+        return new TrustedDirectoryServiceStatic(enableIGTestTrustedDirectory, testDirectoryFQDN);
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceHeaplet.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceHeaplet.java
@@ -21,11 +21,14 @@ import java.time.Duration;
 
 import org.forgerock.openig.heap.GenericHeaplet;
 import org.forgerock.openig.heap.HeapException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.forgerock.sapi.gateway.jwks.cache.caffeine.CaffeineCache;
 
 public class TrustedDirectoryServiceHeaplet extends GenericHeaplet {
 
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final Boolean DEFAULT_IG_TEST_DIRECTORY_ENABLED = false;
 
     @Override
@@ -43,6 +46,9 @@ public class TrustedDirectoryServiceHeaplet extends GenericHeaplet {
                 .defaultTo(null)
                 .asString();
 
+
+        logger.debug("Creating Trusted Directory Service with enableIGTestTrustedDirectory: {}, testDirectoryFQDN: {}",
+                enableIGTestTrustedDirectory, testDirectoryFQDN);
         return new TrustedDirectoryServiceStatic(enableIGTestTrustedDirectory, testDirectoryFQDN);
     }
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStatic.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStatic.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TrustedDirectoryServiceStatic implements TrustedDirectoryService {
+
+    Map<String, TrustedDirectory> directoryConfigurations;
+
+    public TrustedDirectoryServiceStatic(Boolean enableIGTestTrustedDirectory, String testDirectoryFQDN) {
+        directoryConfigurations = new HashMap<>();
+
+        addOpenBankingTestTrustedDirectory();
+        if(enableIGTestTrustedDirectory) {
+            addGatewayTestTrustedDirectory(testDirectoryFQDN);
+        }
+    }
+
+    private void addGatewayTestTrustedDirectory(String testDirectoryFQDN) {
+         TrustedDirectory secureApiGatewayTrustedDirectory = new TrustedDirectorySecureApiGateway(testDirectoryFQDN);
+         directoryConfigurations.put(secureApiGatewayTrustedDirectory.getIssuer(), secureApiGatewayTrustedDirectory);
+    }
+
+    @Override
+    public TrustedDirectory getTrustedDirectoryConfiguration(String issuer) {
+        return directoryConfigurations.get(issuer);
+    }
+
+    private void addOpenBankingTestTrustedDirectory() {
+        TrustedDirectory openBankingTestDirectory =  new TrustedDirectoryOpenBankingTest();
+        directoryConfigurations.put(openBankingTestDirectory.getIssuer(), openBankingTestDirectory);
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTestTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTestTest.java
@@ -29,7 +29,7 @@ class TrustedDirectoryOpenBankingTestTest {
         assertThat(trustedDirectory.getJwksUri()).isEqualTo(TrustedDirectoryOpenBankingTest.jwksUri);
         assertThat(trustedDirectory.softwareStatementHoldsJwksUri()).isTrue();
         assertThat(trustedDirectory.getSoftwareStatementJwksClaimName()).isNull();
-        assertThat(trustedDirectory.getSoftwareStatementJwksUriClaimFName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareJwksUriClaimName);
+        assertThat(trustedDirectory.getSoftwareStatementJwksUriClaimName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareJwksUriClaimName);
         assertThat(trustedDirectory.getSoftwareStatementOrgIdClaimName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareStatementOrgIdClaimName);
         assertThat(trustedDirectory.getSoftwareStatementSoftwareIdClaimName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareStatementSoftwareIdClaimName);
     }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTestTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTestTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TrustedDirectoryOpenBankingTestTest {
+
+    TrustedDirectoryOpenBankingTest trustedDirectory = new TrustedDirectoryOpenBankingTest();
+
+    @Test
+    void testGetters(){
+        assertThat(trustedDirectory.getIssuer()).isEqualTo(TrustedDirectoryOpenBankingTest.issuer);
+        assertThat(trustedDirectory.getJwksUri()).isEqualTo(TrustedDirectoryOpenBankingTest.jwksUri);
+        assertThat(trustedDirectory.softwareStatementHoldsJwksUri()).isTrue();
+        assertThat(trustedDirectory.getSoftwareStatementJwksClaimName()).isNull();
+        assertThat(trustedDirectory.getSoftwareStatementJwksUriClaimFName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareJwksUriClaimName);
+        assertThat(trustedDirectory.getSoftwareStatementOrgIdClaimName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareStatementOrgIdClaimName);
+        assertThat(trustedDirectory.getSoftwareStatementSoftwareIdClaimName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareStatementSoftwareIdClaimName);
+    }
+
+}

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGatewayTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGatewayTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TrustedDirectorySecureApiGatewayTest {
+
+    private static final String testDirectoryFQDN = "https://saig.bigbank.com/jwkms/apiclient/jwks";
+    TrustedDirectorySecureApiGateway trustedDirectory = new TrustedDirectorySecureApiGateway(testDirectoryFQDN);
+
+    @Test
+    void checkFieldValues() {
+        // Given
+        // When
+        // Then
+        assertThat(trustedDirectory.getIssuer()).isEqualTo(TrustedDirectorySecureApiGateway.issuer);
+        assertThat(trustedDirectory.getJwksUri()).isEqualTo(testDirectoryFQDN);
+        assertThat(trustedDirectory.softwareStatementHoldsJwksUri()).isFalse();
+        assertThat(trustedDirectory.getSoftwareStatementJwksUriClaimFName()).isNull();
+        assertThat(trustedDirectory.getSoftwareStatementJwksClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementJwksClaimName);
+        assertThat(trustedDirectory.getSoftwareStatementOrgIdClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementOrgIdClaimName);
+        assertThat(trustedDirectory.getSoftwareStatementSoftwareIdClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementSoftwareIdClaimName);
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGatewayTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGatewayTest.java
@@ -16,9 +16,7 @@
 package com.forgerock.sapi.gateway.trusteddirectories;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class TrustedDirectorySecureApiGatewayTest {
@@ -34,7 +32,7 @@ class TrustedDirectorySecureApiGatewayTest {
         assertThat(trustedDirectory.getIssuer()).isEqualTo(TrustedDirectorySecureApiGateway.issuer);
         assertThat(trustedDirectory.getJwksUri()).isEqualTo(testDirectoryFQDN);
         assertThat(trustedDirectory.softwareStatementHoldsJwksUri()).isFalse();
-        assertThat(trustedDirectory.getSoftwareStatementJwksUriClaimFName()).isNull();
+        assertThat(trustedDirectory.getSoftwareStatementJwksUriClaimName()).isNull();
         assertThat(trustedDirectory.getSoftwareStatementJwksClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementJwksClaimName);
         assertThat(trustedDirectory.getSoftwareStatementOrgIdClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementOrgIdClaimName);
         assertThat(trustedDirectory.getSoftwareStatementSoftwareIdClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementSoftwareIdClaimName);

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStaticTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStaticTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TrustedDirectoryServiceStaticTest {
+
+    @BeforeEach
+    void setUp() {
+
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void getTrustedDirectoryConfiguration_IGTestDirectoryEnabled() {
+        // Given
+        Boolean enableIGTestTrustedDirectory = true;
+        String testDirectoryFQDN = "https://sapi.bigbank.com/jwkms/apiclient/jwks";
+        TrustedDirectoryService trustedDirectoryService = new TrustedDirectoryServiceStatic(enableIGTestTrustedDirectory, testDirectoryFQDN);
+        // When
+        TrustedDirectory directoryConfig = trustedDirectoryService.getTrustedDirectoryConfiguration(TrustedDirectorySecureApiGateway.issuer);
+
+        // Then
+        assertThat(directoryConfig).isNotNull();
+        assertThat(directoryConfig.getIssuer()).isEqualTo(TrustedDirectorySecureApiGateway.issuer);
+        assertThat(directoryConfig.getJwksUri()).isEqualTo(testDirectoryFQDN);
+        assertThat(directoryConfig.softwareStatementHoldsJwksUri()).isEqualTo(false);
+        assertThat(directoryConfig.getSoftwareStatementJwksUriClaimFName()).isNull();
+        assertThat(directoryConfig.getSoftwareStatementJwksClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementJwksClaimName);
+        assertThat(directoryConfig.getSoftwareStatementOrgIdClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementOrgIdClaimName);
+        assertThat(directoryConfig.getSoftwareStatementSoftwareIdClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementSoftwareIdClaimName);
+    }
+
+    @Test
+    void getTrustedDirectoryConfiguration_IGTestDirectoryNotEnabled() {
+        // Given
+        Boolean enableIGTestTrustedDirectory = false;
+        String testDirectoryFQDN = "https://ig.bigbank.com/jwkms/apiclient/jwks";
+        TrustedDirectoryService trustedDirectoryService = new TrustedDirectoryServiceStatic(enableIGTestTrustedDirectory, testDirectoryFQDN);
+        // When
+        TrustedDirectory directoryConfig = trustedDirectoryService.getTrustedDirectoryConfiguration(TrustedDirectorySecureApiGateway.issuer);
+
+        // Then
+        assertThat(directoryConfig).isNull();
+    }
+
+    @Test
+    void getTrustedDirectoryConfiguration_getOpenBankingTestTrustedDirectory(){
+        // Given
+        Boolean enableIGTestTrustedDirectory = false;
+        String testDirectoryFQDN = "https://ig.bigbank.com/jwkms/apiclient/jwks";
+        TrustedDirectoryService trustedDirectoryService = new TrustedDirectoryServiceStatic(enableIGTestTrustedDirectory, testDirectoryFQDN);
+        // When
+        TrustedDirectory directoryConfig = trustedDirectoryService.getTrustedDirectoryConfiguration(TrustedDirectoryOpenBankingTest.issuer);
+
+        // Then
+        assertThat(directoryConfig).isNotNull();
+        assertThat(directoryConfig.getIssuer()).isEqualTo(TrustedDirectoryOpenBankingTest.issuer);
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStaticTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStaticTest.java
@@ -16,7 +16,6 @@
 package com.forgerock.sapi.gateway.trusteddirectories;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,7 +46,7 @@ class TrustedDirectoryServiceStaticTest {
         assertThat(directoryConfig.getIssuer()).isEqualTo(TrustedDirectorySecureApiGateway.issuer);
         assertThat(directoryConfig.getJwksUri()).isEqualTo(testDirectoryFQDN);
         assertThat(directoryConfig.softwareStatementHoldsJwksUri()).isEqualTo(false);
-        assertThat(directoryConfig.getSoftwareStatementJwksUriClaimFName()).isNull();
+        assertThat(directoryConfig.getSoftwareStatementJwksUriClaimName()).isNull();
         assertThat(directoryConfig.getSoftwareStatementJwksClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementJwksClaimName);
         assertThat(directoryConfig.getSoftwareStatementOrgIdClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementOrgIdClaimName);
         assertThat(directoryConfig.getSoftwareStatementSoftwareIdClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementSoftwareIdClaimName);


### PR DESCRIPTION
The config for a trusted directory should be obtained via a service

**Note:** For now, while developing this config, it is hard coded in specific classes. Once the config has been developed so that it holds all the information needed about a TrustedDirectory, this information can be held in a store. Probably it will be stored in IDM as a managed object. Other alternatives could be to store it in Mongo, or in a config file etc. 
 
Issue: https://github.com/secureapigateway/secureapigateway/issues/728