### PR TITLE
729: FetchApiClientFilter impl which queries IDM for ApiClient data

### DIFF
--- a/.github/workflows/slackNotification.yml
+++ b/.github/workflows/slackNotification.yml
@@ -1,0 +1,18 @@
+name: Check Changes
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    name: Push Slack Notification
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        if: success()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.WEBHOOK_SBAT_DEV_SLACK }}
+          SLACK_COLOR: ${{ job.status }}

--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -400,6 +400,15 @@
       }
     },
     {
+      "name": "TrustedDirectoriesService",
+      "type": "TrustedDirectoriesService",
+      "comment": "Used to obtain meta information about a trusted directory by look up using the 'iss' field value",
+      "config": {
+        "enableIGTestTrustedDirectory": true,
+        "SecureApiGatewayJwksUri": "https://&{ig.fqdn}/jwkms/apiclient/jwks"
+      }
+    },
+    {
       "name": "RsaJwtSignatureValidator",
       "type": "RsaJwtSignatureValidator"
     }

--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -6,6 +6,9 @@
     "oauth2": {
       "tokenEndpointAuthMethodsSupported": ["private_key_jwt"]
     },
+    "urls": {
+      "idmGetApiClientBaseUri": "https://&{identity.platform.fqdn}/openidm/managed/apiClient"
+    },
     "vertxConfig": {
       "maxHeaderSize": 16384,
       "initialSettings": {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -77,10 +77,7 @@
             "file": "SSAVerifier.groovy",
             "clientHandler": "OBClientHandler",
             "args": {
-              "routeArgSSAIssuerJwksUrls": {
-                "OpenBanking Ltd": "${urlDecode('https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks')}",
-                "test-publisher": "${urlDecode('https://&{ig.fqdn}/jwkms/apiclient/jwks')}"
-              },
+              "trustedDirectoryService": "${heap['TrustedDirectoriesService']}",
               "jwtSignatureValidator": "${heap['RsaJwtSignatureValidator']}"
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
@@ -89,15 +89,6 @@
           }
         },
         {
-          "comment": "Add ApiClient data to context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "com.forgerock.sapi.gateway.dcr.FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "https://&{identity.platform.fqdn}/openidm/managed/apiClient",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
-        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
@@ -89,6 +89,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "com.forgerock.sapi.gateway.dcr.FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "https://&{identity.platform.fqdn}/openidm/managed/apiClient",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
@@ -110,6 +110,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "com.forgerock.sapi.gateway.dcr.FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "https://&{identity.platform.fqdn}/openidm/managed/apiClient",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
@@ -110,15 +110,6 @@
           }
         },
         {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "com.forgerock.sapi.gateway.dcr.FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "https://&{identity.platform.fqdn}/openidm/managed/apiClient",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
-        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -110,6 +110,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "com.forgerock.sapi.gateway.dcr.FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "https://&{identity.platform.fqdn}/openidm/managed/apiClient",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -110,15 +110,6 @@
           }
         },
         {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "com.forgerock.sapi.gateway.dcr.FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "https://&{identity.platform.fqdn}/openidm/managed/apiClient",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
-        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -99,6 +99,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -118,6 +118,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -108,6 +108,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -118,6 +118,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -100,6 +100,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -118,6 +118,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -99,6 +99,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -118,6 +118,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -99,6 +99,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -118,6 +118,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -99,6 +99,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -118,6 +118,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -99,6 +99,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
@@ -98,6 +98,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -118,6 +118,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -99,6 +99,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -118,6 +118,15 @@
           }
         },
         {
+          "comment": "Add ApiClient data to the context attributes",
+          "name": "FetchApiClientFilter",
+          "type": "FetchApiClientFilter",
+          "config": {
+            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
+            "clientHandler": "IDMClientHandler"
+          }
+        },
+        {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/jwt/JwtUtils.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/forgerock/sapi/gateway/jwt/JwtUtils.groovy
@@ -1,0 +1,41 @@
+package com.forgerock.sapi.gateway.jwt
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.forgerock.json.jose.common.JwtReconstruction
+import org.forgerock.json.jose.jws.SignedJwt
+import org.forgerock.json.jose.jwt.JwtClaimsSet
+import org.forgerock.json.jose.jwt.Jwt
+
+
+class JwtUtils {
+
+    static private final Logger logger = LoggerFactory.getLogger(getClass())
+
+    static Jwt getSignedJwtFromString(String logPrefix, String jwtAsString, String jwtName){
+        logger.debug(logPrefix + "Parsing jwt {}", jwtName);
+        Jwt jwt
+        try {
+            jwt = new JwtReconstruction().reconstructJwt(jwtAsString, SignedJwt.class)
+        } catch (e) {
+            logger.warn(logPrefix + "failed to decode registration request JWT", e)
+            return null
+        }
+        return jwt
+    }
+
+    static JwtClaimsSet getClaimsFromSignedJwtAsString(String logPrefix, String jwtAsString, String jwtName){
+        Jwt jwt = getJwtFromString(logPrefix, jwtAsString, jwtName)
+        return jwt.getClaimsSet()
+    }
+
+    static boolean hasExpired(JwtClaimsSet claimSet){
+        Boolean hasExpired = false
+        Date expirationTime = claimSet.getExpirationTime()
+        if (expirationTime.before(new Date())) {
+            hasExpired = true
+        }
+        return hasExpired
+    }
+
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
@@ -24,6 +24,7 @@ import com.forgerock.sapi.gateway.fapi.v1.FAPIAdvancedDCRValidationFilter;
 import com.forgerock.sapi.gateway.jwks.RestJwkSetService;
 import com.forgerock.sapi.gateway.jwks.cache.caffeine.CaffeineCachingJwkSetService;
 import com.forgerock.sapi.gateway.jws.RsaJwtSignatureValidator;
+import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectoryService;
 
 public class SecureApiGatewayClassAliasResolver implements ClassAliasResolver {
     private static final Map<String, Class<?>> ALIASES = new HashMap<>();
@@ -33,6 +34,7 @@ public class SecureApiGatewayClassAliasResolver implements ClassAliasResolver {
         ALIASES.put("CaffeineCachingJwkSetService", CaffeineCachingJwkSetService.class);
         ALIASES.put("RestJwkSetService", RestJwkSetService.class);
         ALIASES.put("RsaJwtSignatureValidator", RsaJwtSignatureValidator.class);
+        ALIASES.put("TrustedDirectoriesService", TrustedDirectoryService.class);
     }
 
     /**

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
@@ -24,7 +24,6 @@ import com.forgerock.sapi.gateway.fapi.v1.FAPIAdvancedDCRValidationFilter;
 import com.forgerock.sapi.gateway.jwks.RestJwkSetService;
 import com.forgerock.sapi.gateway.jwks.cache.caffeine.CaffeineCachingJwkSetService;
 import com.forgerock.sapi.gateway.jws.RsaJwtSignatureValidator;
-import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectoryService;
 
 public class SecureApiGatewayClassAliasResolver implements ClassAliasResolver {
     private static final Map<String, Class<?>> ALIASES = new HashMap<>();
@@ -35,6 +34,7 @@ public class SecureApiGatewayClassAliasResolver implements ClassAliasResolver {
         ALIASES.put("RestJwkSetService", RestJwkSetService.class);
         ALIASES.put("RsaJwtSignatureValidator", RsaJwtSignatureValidator.class);
         ALIASES.put("TrustedDirectoriesService", TrustedDirectoryService.class);
+        ALIASES.put("FetchApiClientFilter", FetchApiClientFilter.class);
     }
 
     /**

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
@@ -20,10 +20,12 @@ import java.util.Map;
 
 import org.forgerock.openig.alias.ClassAliasResolver;
 
+import com.forgerock.sapi.gateway.dcr.FetchApiClientFilter;
 import com.forgerock.sapi.gateway.fapi.v1.FAPIAdvancedDCRValidationFilter;
 import com.forgerock.sapi.gateway.jwks.RestJwkSetService;
 import com.forgerock.sapi.gateway.jwks.cache.caffeine.CaffeineCachingJwkSetService;
 import com.forgerock.sapi.gateway.jws.RsaJwtSignatureValidator;
+import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectoryService;
 
 public class SecureApiGatewayClassAliasResolver implements ClassAliasResolver {
     private static final Map<String, Class<?>> ALIASES = new HashMap<>();

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/ApiClient.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/ApiClient.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.dcr;
+
+import java.net.URI;
+
+import org.forgerock.json.jose.jws.SignedJwt;
+
+public class ApiClient {
+
+    private String oauth2ClientId;
+    private String softwareClientId;
+    private String clientName;
+    private URI jwksUri;
+    private SignedJwt softwareStatementAssertion;
+    private ApiClientOrganisation organisation;
+
+    public ApiClient(){
+    }
+
+    public String getOauth2ClientId() {
+        return oauth2ClientId;
+    }
+
+    public void setOauth2ClientId(String oauth2ClientId) {
+        this.oauth2ClientId = oauth2ClientId;
+    }
+
+    public String getSoftwareClientId() {
+        return softwareClientId;
+    }
+
+    public void setSoftwareClientId(String softwareClientId) {
+        this.softwareClientId = softwareClientId;
+    }
+
+    public String getClientName() {
+        return clientName;
+    }
+
+    public void setClientName(String clientName) {
+        this.clientName = clientName;
+    }
+
+    public URI getJwksUri() {
+        return jwksUri;
+    }
+
+    public void setJwksUri(URI jwksUri) {
+        this.jwksUri = jwksUri;
+    }
+
+    public SignedJwt getSoftwareStatementAssertion() {
+        return softwareStatementAssertion;
+    }
+
+    public void setSoftwareStatementAssertion(SignedJwt softwareStatementAssertion) {
+        this.softwareStatementAssertion = softwareStatementAssertion;
+    }
+
+    public ApiClientOrganisation getOrganisation() {
+        return organisation;
+    }
+
+    public void setOrganisation(ApiClientOrganisation organisation) {
+        this.organisation = organisation;
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/ApiClient.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/ApiClient.java
@@ -19,6 +19,9 @@ import java.net.URI;
 
 import org.forgerock.json.jose.jws.SignedJwt;
 
+/**
+ * Data object which represents a registered OAuth2 client.
+ */
 public class ApiClient {
 
     private String oauth2ClientId;

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/ApiClient.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/ApiClient.java
@@ -25,11 +25,37 @@ import org.forgerock.json.jose.jws.SignedJwt;
  */
 public class ApiClient {
 
+    /**
+     * The OAuth2 Client ID for this client. This is generated and assigned at registration.
+     *
+     * This ID can uniquely identify the ApiClient.
+     */
     private String oauth2ClientId;
+
+    /**
+     * The Client ID for this client as defined in the software statement used to at registration (not necessarily unique).
+     */
     private String softwareClientId;
+
+    /**
+     * Name of the client
+     */
     private String clientName;
+
+    /**
+     * The URI of the JWKS which contains the certificates which can be used by this ApiClient for transport and
+     * signing purposes.
+     */
     private URI jwksUri;
+
+    /**
+     * The Software Statement Assertions (SSA), which is a signed JWT containing the Software Statement registered.
+     */
     private SignedJwt softwareStatementAssertion;
+
+    /**
+     * The organisation that this client belongs to
+     */
     private ApiClientOrganisation organisation;
 
     public ApiClient(){

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/ApiClient.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/ApiClient.java
@@ -16,6 +16,7 @@
 package com.forgerock.sapi.gateway.dcr;
 
 import java.net.URI;
+import java.util.Objects;
 
 import org.forgerock.json.jose.jws.SignedJwt;
 
@@ -80,5 +81,35 @@ public class ApiClient {
 
     public void setOrganisation(ApiClientOrganisation organisation) {
         this.organisation = organisation;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final ApiClient apiClient = (ApiClient) o;
+        return Objects.equals(oauth2ClientId, apiClient.oauth2ClientId)
+                && Objects.equals(softwareClientId, apiClient.softwareClientId)
+                && Objects.equals(clientName, apiClient.clientName)
+                && Objects.equals(jwksUri, apiClient.jwksUri)
+                && Objects.equals(softwareStatementAssertion, apiClient.softwareStatementAssertion)
+                && Objects.equals(organisation, apiClient.organisation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(oauth2ClientId, softwareClientId, clientName, jwksUri, softwareStatementAssertion, organisation);
+    }
+
+    @Override
+    public String toString() {
+        return "ApiClient{" +
+                "oauth2ClientId='" + oauth2ClientId + '\'' +
+                ", softwareClientId='" + softwareClientId + '\'' +
+                ", clientName='" + clientName + '\'' +
+                ", jwksUri=" + jwksUri +
+                ", softwareStatementAssertion=" + softwareStatementAssertion +
+                ", organisation=" + organisation +
+                '}';
     }
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/ApiClientOrganisation.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/ApiClientOrganisation.java
@@ -15,6 +15,9 @@
  */
 package com.forgerock.sapi.gateway.dcr;
 
+/**
+ * Data object which represents an Organisation to which one or more {@link ApiClient} objects belong
+ */
 public class ApiClientOrganisation {
 
     private final String id;

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/ApiClientOrganisation.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/ApiClientOrganisation.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.dcr;
 
+import java.util.Objects;
+
 /**
  * Data object which represents an Organisation to which one or more {@link ApiClient} objects belong
  */
@@ -34,5 +36,26 @@ public class ApiClientOrganisation {
 
     public String getName() {
         return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final ApiClientOrganisation that = (ApiClientOrganisation) o;
+        return Objects.equals(id, that.id) && Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        return "ApiClientOrganisation{" +
+                "id='" + id + '\'' +
+                ", name='" + name + '\'' +
+                '}';
     }
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/ApiClientOrganisation.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/ApiClientOrganisation.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.dcr;
+
+public class ApiClientOrganisation {
+
+    private final String id;
+    private final String name;
+
+    public ApiClientOrganisation(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/ApiClientOrganisation.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/ApiClientOrganisation.java
@@ -22,7 +22,14 @@ import java.util.Objects;
  */
 public class ApiClientOrganisation {
 
+    /**
+     * Unique identifier of this organisation.
+     */
     private final String id;
+
+    /**
+     * Organisation name, typically the company name.
+     */
     private final String name;
 
     public ApiClientOrganisation(String id, String name) {

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/FetchApiClientFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/FetchApiClientFilter.java
@@ -56,6 +56,7 @@ public class FetchApiClientFilter implements Filter {
     public FetchApiClientFilter(Client clientHandler, String idmGetApiClientBaseUri, String accessTokenClientIdClaim) {
         Reject.ifNull(clientHandler, "clientHandler must be provided");
         Reject.ifBlank(idmGetApiClientBaseUri, "idmGetApiClientBaseUri must be provided");
+        Reject.ifBlank(accessTokenClientIdClaim, "accessTokenClientIdClaim must be provided");
         this.httpClient = clientHandler;
         this.idmGetApiClientBaseUri = idmGetApiClientBaseUri;
         this.accessTokenClientIdClaim = accessTokenClientIdClaim;
@@ -121,6 +122,9 @@ public class FetchApiClientFilter implements Filter {
      * - idmGetApiClientBaseUri: the base uri used to build the IDM query to get the apiClient, the client_id is expected
      * to be appended to this uri (and some query params).
      * - clientHandler: the clientHandler to use to call out to IDM.
+     *
+     * Optional config:
+     * - accessTokenClientIdClaim: name of the claim used to extract the client_id from the access_token, defaults to "aud"
      *
      * Example config:
      * {

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/FetchApiClientFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/FetchApiClientFilter.java
@@ -126,7 +126,7 @@ public class FetchApiClientFilter implements Filter {
                                                                   ioe -> { throw new Exception("Failed to decode apiClient response json", ioe); });
                              }, nte -> Promises.newExceptionPromise(new Exception(nte)));
         } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
+            return Promises.newExceptionPromise(new Exception(e));
         }
     }
 

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/FetchApiClientFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/FetchApiClientFilter.java
@@ -130,7 +130,7 @@ public class FetchApiClientFilter implements Filter {
      * {
      *           "comment": "Add ApiClient data to the context attributes",
      *           "name": "FetchApiClientFilter",
-     *           "type": "com.forgerock.sapi.gateway.dcr.FetchApiClientFilter",
+     *           "type": "FetchApiClientFilter",
      *           "config": {
      *             "idmGetApiClientBaseUri": "https://&{identity.platform.fqdn}/openidm/managed/apiClient",
      *             "clientHandler": "IDMClientHandler"

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/FetchApiClientFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/FetchApiClientFilter.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.dcr;
+
+import static org.forgerock.openig.util.JsonValues.requiredHeapObject;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+
+import org.forgerock.http.Client;
+import org.forgerock.http.Filter;
+import org.forgerock.http.Handler;
+import org.forgerock.http.oauth2.OAuth2Context;
+import org.forgerock.http.protocol.Request;
+import org.forgerock.http.protocol.Response;
+import org.forgerock.http.protocol.Status;
+import org.forgerock.json.JsonValue;
+import org.forgerock.json.jose.common.JwtReconstruction;
+import org.forgerock.json.jose.jws.SignedJwt;
+import org.forgerock.openig.heap.GenericHeaplet;
+import org.forgerock.openig.heap.HeapException;
+import org.forgerock.services.context.AttributesContext;
+import org.forgerock.services.context.Context;
+import org.forgerock.util.promise.NeverThrowsException;
+import org.forgerock.util.promise.Promise;
+import org.forgerock.util.promise.Promises;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.forgerock.sapi.gateway.fapi.FAPIUtils;
+
+public class FetchApiClientFilter implements Filter {
+
+    public static final String API_CLIENT_ATTR_KEY = "apiClient";
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final Client httpClient;
+    private final String idmGetApiClientBaseUri;
+
+    public FetchApiClientFilter(Client clientHandler, String idmGetApiClientBaseUri) {
+        this.httpClient = clientHandler;
+        this.idmGetApiClientBaseUri = idmGetApiClientBaseUri;
+    }
+
+    @Override
+    public Promise<Response, NeverThrowsException> filter(Context context, Request request, Handler next) {
+        final OAuth2Context oAuth2Context = context.asContext(OAuth2Context.class);
+        final Map<String, Object> info = oAuth2Context.getAccessToken().getInfo();
+        if (!info.containsKey("aud")) {
+            logger.error("({}) access token is missing required aud claim", FAPIUtils.getFapiInteractionIdForDisplay(context));
+            return Promises.newResultPromise(new Response(Status.INTERNAL_SERVER_ERROR));
+        }
+        final String clientId = (String)info.get("aud");
+        return getApiClientFromIdm(clientId).thenAsync(apiClient -> {
+            context.asContext(AttributesContext.class).getAttributes().put(API_CLIENT_ATTR_KEY, apiClient);
+            return next.handle(context, request);
+        }, ex -> {
+            logger.error("(" + FAPIUtils.getFapiInteractionIdForDisplay(context) + ") failed to get apiClient from idm due to exception", ex);
+            return Promises.newResultPromise(new Response(Status.INTERNAL_SERVER_ERROR));
+        });
+    }
+
+    private Promise<ApiClient, Exception> getApiClientFromIdm(String clientId) {
+        try {
+            return httpClient.send(new Request().setMethod("GET")
+                            .setUri(idmGetApiClientBaseUri + clientId + "?_fields=apiClientOrg,*"))
+                    .thenAsync(response -> {
+                        if (!response.getStatus().isSuccessful()) {
+                            throw new Exception("Failed to get ApiClient from IDM, response status: " + response.getStatus());
+                        }
+                        return response.getEntity().getJsonAsync().then(json -> convertJsonObjectToApiClient(JsonValue.json(json)),
+                                                                        ioe -> { throw new Exception("Failed to decode apiClient response json", ioe); });
+                    }, nte -> Promises.newExceptionPromise(new Exception(nte)));
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ApiClient convertJsonObjectToApiClient(JsonValue apiClientJson) {
+        final ApiClient apiClient = new ApiClient();
+        apiClient.setClientName(apiClientJson.get("name").asString());
+        apiClient.setOauth2ClientId(apiClientJson.get("oauth2ClientId").asString());
+        apiClient.setSoftwareStatementAssertion(apiClientJson.get("ssa").as(ssa -> new JwtReconstruction().reconstructJwt(ssa.asString(), SignedJwt.class)));
+        apiClient.setSoftwareClientId(apiClientJson.get("id").asString());
+        apiClient.setJwksUri(apiClientJson.get("jwksUri").as(jwks -> URI.create(jwks.asString())));
+        apiClient.setOrganisation(apiClientJson.get("apiClientOrg").as(org -> {
+            final JsonValue orgJson = JsonValue.json(org);
+            final String orgId = orgJson.get("id").asString();
+            final String orgName = orgJson.get("name").asString();
+            return new ApiClientOrganisation(orgId, orgName);
+        }));
+        return apiClient;
+    }
+
+    public static class Heaplet extends GenericHeaplet {
+
+        @Override
+        public Object create() throws HeapException {
+            final Handler clientHandler = config.get("clientHandler").as(requiredHeapObject(heap, Handler.class));
+            final Client httpClient = new Client(clientHandler);
+
+            String idmGetApiClientBaseUri = config.get("idmGetApiClientBaseUri").required().asString();
+            if (!idmGetApiClientBaseUri.endsWith("/")) {
+                idmGetApiClientBaseUri = idmGetApiClientBaseUri + '/';
+            }
+
+            return new FetchApiClientFilter(httpClient, idmGetApiClientBaseUri);
+        }
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/FetchApiClientFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/FetchApiClientFilter.java
@@ -72,7 +72,7 @@ public class FetchApiClientFilter implements Filter {
     private final Client httpClient;
 
     /**
-     * The base to use in GET requests to IDM to query for the apiClient
+     * The base uri to use in GET requests to IDM to query for the apiClient
      *
      * Of the form: https://$IDM_HOST/openidm/managed/$API_CLIENT_MANAGED_OBJECT_NAME
      */
@@ -152,7 +152,8 @@ public class FetchApiClientFilter implements Filter {
      * Mandatory config:
      * - idmGetApiClientBaseUri: the base uri used to build the IDM query to get the apiClient, the client_id is expected
      * to be appended to this uri (and some query params).
-     * - clientHandler: the clientHandler to use to call out to IDM.
+     * - clientHandler: the clientHandler to use to call out to IDM (must be configured with the credentials required to
+     * query IDM)
      *
      * Optional config:
      * - accessTokenClientIdClaim: name of the claim used to extract the client_id from the access_token, defaults to "aud"

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+/**
+ * A Trusted Directory is an external 'trust anchor' that the Secure API Gateway should trust to be the issuer
+ * of software statements and the certificates associated with those statements. This interface allows access to
+ * configuration information for a trusted directory. In the UK this is the Open Banking Directory, or the Open Banking
+ * Sandbox Directory. It is trusted by both the ApiClient and the ApiProvider. In other eco-systems the registry will
+ * be different. In some cases it can be a registry provided by the ApiProvider. For example a bank wishing to provide
+ * innovative new custom APIs outside of a regulated system could create their own Trusted Registry.
+ *
+ * @see <a href="https://github.com/SecureApiGateway/SecureApiGateway/wiki/About-Dynamic-Client-Registration">
+ *     About Dynamic Client Registration</a>
+ */
+public interface TrustedDirectory {
+    /**
+     * @return the value that can be expected to be found in the issuer field of Software Statements issued
+     * by the Trusted Directory
+     */
+    String getIssuer();
+
+    /**
+     *
+     * @return a String containing the jwks_uri against which software statement issued by this trusted directory
+     * can be validated
+     */
+    String getJwksUri();
+
+    /**
+     *
+     * @return true if the software statement contains the full JWKS entry - this is not recommended as it is brittle.
+     * Using a jwks_uri against which Certificates associated with Software Statement can be validated allows for
+     * key rotation
+     */
+    boolean softwareStatementHoldsJwksUri();
+    /**
+     *
+     * @return If @link #softwareStatementHoldsJwksUri() returns true this method will return the name of the claim in the
+     * software statement that holds the jwks_uri against which certificates associated with the software statement can
+     * be found. If @link #softwareStatementHoldsJwksUri() returns false this will return null
+     */
+    String getSoftwareStatementJwksUriClaimName();
+
+
+    /**
+     * If @link #softwareStatementHoldsJwksUri() returns false this method will return the name of the Software Statement
+     * claim in which the JWKS entry maybe found. If it returns true, this method will return null
+     */
+    String getSoftwareStatementJwksClaimName();
+
+    /**
+     *
+     * @return the name of the claim in the software statement that holds a unique identifier for the organisation
+     * to which the Software Statement belongs
+     */
+    String getSoftwareStatementOrgIdClaimName();
+
+    /**
+     *
+     * @return the name of the claim in the software statement that holds a unique identifier for the software statement
+     */
+    String getSoftwareStatementSoftwareIdClaimName();
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
+
+    /*
+     * The value expected to be found in the issuer field of software statements issued by the Open Banking Test
+     * directory
+     */
+    final static String issuer = "OpenBanking Ltd";
+
+
+    final static boolean softwareStatementHoldsJwksUri = true;
+
+    /*
+     * The URL at which the Open Banking Test Directory JWKS are held, containing public certificates that may be used
+     * to validate Open Banking Test directory issues Software Statements.
+     */
+    final static String jwksUri = "https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks";
+
+    /*
+     * The name of the claim in the Open Banking Test Directory issued software statement that holds the jwks_uri
+     * against which certificates associated with this software statement may be validated
+     */
+    final static String softwareJwksUriClaimName = "software_jwks_endpoint";
+    /*
+     * The name of the claim in the Open Banking Test Directory issued software statement that holds a uid for the
+     * organisation
+     */
+    final static String softwareStatementOrgIdClaimName = "org_id";
+    /*
+     * The name of the claim in the Open Banking Test Directory issued software statement that holds a uid for the
+     * software statement
+     */
+    final static String softwareStatementSoftwareIdClaimName = "software_id";
+
+    @Override
+    public String getIssuer() {
+        return issuer;
+    }
+
+    @Override
+    public String getJwksUri() {
+        return jwksUri;
+    }
+
+    @Override
+    public boolean softwareStatementHoldsJwksUri() {
+        return softwareStatementHoldsJwksUri;
+    }
+
+    @Override
+    public String getSoftwareStatementJwksUriClaimName() {
+        return softwareJwksUriClaimName;
+    }
+
+    @Override
+    public String getSoftwareStatementJwksClaimName() {
+        return null;
+    }
+
+    @Override
+    public String getSoftwareStatementOrgIdClaimName() {
+        return softwareStatementOrgIdClaimName;
+    }
+
+    @Override
+    public String getSoftwareStatementSoftwareIdClaimName() {
+        return softwareStatementSoftwareIdClaimName;
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+/**
+ * Holds static configuration information for the Trusted Directory provided by the Secure API Gateway itself. For
+ * development and test purposes it is useful to be able to use the Secure API Gateway to issue SSAs and Certificates
+ * associated with the SSA itself.
+ */
+public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
+
+    /*
+     * The value expected to be found in the issuer field of software statements issued by the Open Banking Test
+     * directory
+     */
+    final static String issuer = "test-publisher";
+
+    /*
+     * The URL at which the Open Banking Test Directory JWKS are held, containing public certificates that may be used
+     * to validate Open Banking Test directory issues Software Statements.
+     */
+    String secureApiGatewayJwksUri = null;
+
+    final static boolean softwareStatementHoldsJwksUri = false;
+
+    final static String softwareStatementJwksClaimName = "software_jwks";
+
+    /*
+     * The name of the claim in the Open Banking Test Directory issued software statement that holds a uid for the
+     * organisation
+     */
+    final static String softwareStatementOrgIdClaimName = "org_id";
+    /*
+     * The name of the claim in the Open Banking Test Directory issued software statement that holds a uid for the
+     * software statement
+     */
+    final static String softwareStatementSoftwareIdClaimName = "software_client_id";
+
+    /**
+     * Constructor
+     * @param secureApiGatewayJwksUri The jwks_uri against which SSAs issued by the Secure API Gateway can be
+     *                                validated
+     */
+    public TrustedDirectorySecureApiGateway(String secureApiGatewayJwksUri){
+        this.secureApiGatewayJwksUri = secureApiGatewayJwksUri;
+    }
+
+    @Override
+    public String getIssuer() {
+        return issuer;
+    }
+
+    @Override
+    public String getJwksUri() {
+        return this.secureApiGatewayJwksUri;
+    }
+
+    @Override
+    public boolean softwareStatementHoldsJwksUri() {
+        return softwareStatementHoldsJwksUri;
+    }
+
+    @Override
+    public String getSoftwareStatementJwksUriClaimName() {
+        return null;
+    }
+
+    @Override
+    public String getSoftwareStatementJwksClaimName() {
+        return softwareStatementJwksClaimName;
+    }
+
+    @Override
+    public String getSoftwareStatementOrgIdClaimName() {
+        return softwareStatementOrgIdClaimName;
+    }
+
+    @Override
+    public String getSoftwareStatementSoftwareIdClaimName() {
+        return softwareStatementSoftwareIdClaimName;
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryService.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryService.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+public interface TrustedDirectoryService {
+
+    TrustedDirectory getTrustedDirectoryConfiguration(String issuer);
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceHeaplet.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceHeaplet.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+import static org.forgerock.openig.util.JsonValues.javaDuration;
+
+import java.time.Duration;
+
+import org.forgerock.openig.heap.GenericHeaplet;
+import org.forgerock.openig.heap.HeapException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.forgerock.sapi.gateway.jwks.cache.caffeine.CaffeineCache;
+
+public class TrustedDirectoryServiceHeaplet extends GenericHeaplet {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Boolean DEFAULT_IG_TEST_DIRECTORY_ENABLED = false;
+
+    @Override
+    public Object create() throws HeapException {
+        return createTrustedDirectoryService();
+    }
+
+    private Object createTrustedDirectoryService() {
+        final Boolean enableIGTestTrustedDirectory = config.get("enableIGTestTrustedDirectory")
+                .as(evaluatedWithHeapProperties())
+                .defaultTo(DEFAULT_IG_TEST_DIRECTORY_ENABLED)
+                .asBoolean();
+        final String secureApiGatewayJwksUri = config.get("SecureApiGatewayJwksUri")
+                .as(evaluatedWithHeapProperties())
+                .defaultTo(null)
+                .asString();
+
+
+        logger.debug("Creating Trusted Directory Service with enableIGTestTrustedDirectory: {}, secureApiGatewayJwksUri: {}",
+                enableIGTestTrustedDirectory, secureApiGatewayJwksUri);
+        return new TrustedDirectoryServiceStatic(enableIGTestTrustedDirectory, secureApiGatewayJwksUri);
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStatic.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStatic.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class provides access to static config data. By static I mean the underlying classes hold Trusted Directory
+ * configuration data that is hard coded. This class allows us to access this information via the TrustedDirectoryService
+ * while we hone what needs to be in the Trusted Directory configuration data. Once we have settled on what data needs
+ * to be held we can then create a TrustedDirectoryService that will read the Trusted Directory configuration from
+ * a store such as Identity Manager in the FIdC.
+ */
+public class TrustedDirectoryServiceStatic implements TrustedDirectoryService {
+
+    private final Map<String, TrustedDirectory> directoryConfigurations;
+
+    /**
+     * Constructor. The Secure API Gateway can itself be a trusted directory. This means it can issue software statements
+     * and issue certificates associated with those software statements. This is useful for development and testing
+     * but SHOULD NOT BE USED IN PRODUCTION. Whether the Secure API Gateway acts as a trusted directory or not is
+     * controlled by the 'enableIGTestTrustedDirectory' parameter.
+     * @param enableIGTestTrustedDirectory indicates if the Secure API Gateway should act as a Trusted Directory.</br>
+     *                                     <b>NOTE: this should NOT be true in production deployments</b>
+     * @param secureApiGatewayJwksUri The jwks_uri against which the signature of SSAs issued by the Trusted Directory
+     *                                may be validated
+     */
+    public TrustedDirectoryServiceStatic(Boolean enableIGTestTrustedDirectory, String secureApiGatewayJwksUri) {
+        directoryConfigurations = new HashMap<>();
+
+        addOpenBankingTestTrustedDirectory();
+        if(enableIGTestTrustedDirectory) {
+            addGatewayTestTrustedDirectory(secureApiGatewayJwksUri);
+        }
+    }
+
+    /**
+     *
+     * @param issuer - the value of the 'iss' field that is used by the Trusted Directory in Software Statement
+     *               Assertions. For the Open Banking Directories for example, this will be "OpenBanking Ltd"
+     * @return The {@code TrustedDirectory} associated with the issuer or null if no value is held for the provided
+     * issuer
+     */
+    @Override
+    public TrustedDirectory getTrustedDirectoryConfiguration(String issuer) {
+        return directoryConfigurations.get(issuer);
+    }
+
+    private void addGatewayTestTrustedDirectory(String testDirectoryFQDN) {
+        TrustedDirectory secureApiGatewayTrustedDirectory = new TrustedDirectorySecureApiGateway(testDirectoryFQDN);
+        directoryConfigurations.put(secureApiGatewayTrustedDirectory.getIssuer(), secureApiGatewayTrustedDirectory);
+    }
+
+    private void addOpenBankingTestTrustedDirectory() {
+        TrustedDirectory openBankingTestDirectory =  new TrustedDirectoryOpenBankingTest();
+        directoryConfigurations.put(openBankingTestDirectory.getIssuer(), openBankingTestDirectory);
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/FetchApiClientFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/FetchApiClientFilterTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.dcr;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.forgerock.json.JsonValue.*;
+
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.forgerock.http.Client;
+import org.forgerock.http.Handler;
+import org.forgerock.http.MutableUri;
+import org.forgerock.http.oauth2.AccessTokenInfo;
+import org.forgerock.http.oauth2.OAuth2Context;
+import org.forgerock.http.protocol.Form;
+import org.forgerock.http.protocol.Request;
+import org.forgerock.http.protocol.Response;
+import org.forgerock.http.protocol.Status;
+import org.forgerock.json.JsonValue;
+import org.forgerock.json.JsonValueException;
+import org.forgerock.json.jose.common.JwtReconstruction;
+import org.forgerock.json.jose.jws.JwsAlgorithm;
+import org.forgerock.json.jose.jws.JwsHeader;
+import org.forgerock.json.jose.jws.SignedJwt;
+import org.forgerock.json.jose.jws.handlers.SigningHandler;
+import org.forgerock.json.jose.jwt.JwtClaimsSet;
+import org.forgerock.openig.handler.Handlers;
+import org.forgerock.openig.heap.HeapException;
+import org.forgerock.openig.heap.HeapImpl;
+import org.forgerock.openig.heap.Name;
+import org.forgerock.services.context.AttributesContext;
+import org.forgerock.services.context.Context;
+import org.forgerock.services.context.RootContext;
+import org.forgerock.util.promise.NeverThrowsException;
+import org.forgerock.util.promise.Promise;
+import org.forgerock.util.promise.Promises;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.dcr.FetchApiClientFilter.Heaplet;
+
+class FetchApiClientFilterTest {
+
+    /**
+     * Mocks the expected response from IDM.
+     *
+     * Validates that it is called with the expected uri (including the expected clientId), and then returns a pre-canned
+     * response json for that clientId.
+     *
+     * If the validation fails then a Runtime exception is returned, which will be thrown when Promise.get is called.
+     */
+    private class IdmResponseHandler implements Handler {
+        private final MutableUri idmBaseUri;
+        private final String expectedClientId;
+        private final JsonValue staticApiClientData;
+
+        private IdmResponseHandler(String idmBaseUri, String expectedClientId, JsonValue staticApiClientData) {
+            try {
+                this.idmBaseUri = MutableUri.uri(idmBaseUri);
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+            this.expectedClientId = expectedClientId;
+            this.staticApiClientData = staticApiClientData;
+        }
+
+        @Override
+        public Promise<Response, NeverThrowsException> handle(Context context, Request request) {
+            final MutableUri requestUri = request.getUri();
+            if (requestUri.getHost().equals(idmBaseUri.getHost()) && requestUri.getScheme().equals(idmBaseUri.getScheme())
+                    && requestUri.getPath().equals(idmBaseUri.getPath() + expectedClientId)) {
+                Response idmResponse = new Response(Status.OK);
+                idmResponse.setEntity(staticApiClientData);
+                return Promises.newResultPromise(idmResponse);
+            }
+            return Promises.newRuntimeExceptionPromise(new IllegalStateException("Unexpected requestUri: " + requestUri));
+        }
+    }
+
+
+    @Test
+    void fetchApiClientUsingMockedIdmResponse() throws Exception {
+        final String idmBaseUri = "http://localhost/openidm/managed/";
+        final String clientId = "1234-5678-9101";
+        final JsonValue idmClientData = createIdmApiClientData(clientId);
+        final IdmResponseHandler idmResponseHandler = new IdmResponseHandler(idmBaseUri, clientId, idmClientData);
+
+        final FetchApiClientFilter filter = new FetchApiClientFilter(new Client(idmResponseHandler), idmBaseUri);
+        final AttributesContext attributesContext = new AttributesContext(new RootContext("root"));
+        final OAuth2Context oauth2Context = new OAuth2Context(attributesContext, createAccessToken(clientId));
+
+        // This is the next filter called after the FetchApiClientFilter
+        final Handler endOfFilterChainHandler = Handlers.NO_CONTENT;
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(oauth2Context, new Request(), endOfFilterChainHandler);
+
+        final Response response = responsePromise.get(1L, TimeUnit.SECONDS);
+        // Verify we hit the end of the chain and got the NO_CONTENT response
+        assertEquals(Status.NO_CONTENT, response.getStatus());
+        // Verify that the context was updated with the apiClient data
+        final ApiClient apiClient = (ApiClient) attributesContext.getAttributes().get("apiClient");
+        assertNotNull(apiClient);
+        verifyIdmClientDataMatchesApiClientObject(idmClientData, apiClient);
+    }
+
+    private static AccessTokenInfo createAccessToken(String clientId) {
+        return new AccessTokenInfo(json(object(field("aud", clientId))), "token", Set.of("scope1"), 0L);
+    }
+
+    @Test
+    void failsWhenNoOAuth2ContextIsFound() {
+        final FetchApiClientFilter filter = new FetchApiClientFilter(new Client(Handlers.INTERNAL_SERVER_ERROR), "notUsed");
+        assertThrows(IllegalArgumentException.class, () -> filter.filter(new RootContext("root"), new Request(), Handlers.FORBIDDEN),
+                "No context of type org.forgerock.http.oauth2.OAuth2Context found");
+    }
+
+    @Test
+    void returnsErrorResponseWhenUnableToDetermineClientId() throws Exception{
+        final FetchApiClientFilter filter = new FetchApiClientFilter(new Client(Handlers.FORBIDDEN), "notUsed");
+        final AccessTokenInfo accessTokenWithoutAudClaim = new AccessTokenInfo(json(object()), "token", Set.of("scope1"), 0L);
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(new OAuth2Context(new RootContext("root"), accessTokenWithoutAudClaim), new Request(), Handlers.FORBIDDEN);
+
+        final Response response = responsePromise.get(1, TimeUnit.SECONDS);
+        assertEquals(Status.INTERNAL_SERVER_ERROR, response.getStatus());
+        // FIXME improve assertion
+    }
+
+    @Test
+    void returnsErrorResponseWhenIdmReturnsErrorResponse() throws Exception {
+        // Mock IDM returning 500 response
+        final Client idmClientHandler = new Client(Handlers.INTERNAL_SERVER_ERROR);
+        final FetchApiClientFilter filter = new FetchApiClientFilter(idmClientHandler, "notUsed");
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(new OAuth2Context(new RootContext("root"), createAccessToken("1234")), new Request(), Handlers.FORBIDDEN);
+
+        final Response response = responsePromise.get(1, TimeUnit.SECONDS);
+        assertEquals(Status.INTERNAL_SERVER_ERROR, response.getStatus());
+        // FIXME improve assertion
+    }
+
+    @Test
+    void returnsErrorResponseWhenIdmReturnsInvalidJsonResponse() throws Exception {
+        // IDM returns a Form instead of json
+        final Client idmClientHandler = new Client((ctx, req) -> Promises.newResultPromise(new Response(Status.OK).setEntity(new Form())));
+        final FetchApiClientFilter filter = new FetchApiClientFilter(idmClientHandler, "notUsed");
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(new OAuth2Context(new RootContext("root"), createAccessToken("1234")), new Request(), Handlers.FORBIDDEN);
+
+        final Response response = responsePromise.get(1, TimeUnit.SECONDS);
+        assertEquals(Status.INTERNAL_SERVER_ERROR, response.getStatus());
+    }
+
+    @Nested
+    class HeapletTests {
+        @Test
+        void failsToConstructIfClientHandlerIsMissing() {
+            final HeapException heapException = assertThrows(HeapException.class, () -> new Heaplet().create(Name.of("test"),
+                    json(object()), new HeapImpl(Name.of("heap"))), "Invalid object declaration");
+            assertEquals(heapException.getCause().getMessage(), "/clientHandler: Expecting a value");
+        }
+
+        @Test
+        void failsToConstructIfIdmUrlIsMissing() {
+            final Handler idmClientHandler = (ctx, req) -> Promises.newResultPromise(new Response(Status.OK));
+            final HeapImpl heap = new HeapImpl(Name.of("heap"));
+            heap.put("idmClientHandler", idmClientHandler);
+
+            assertThrows(JsonValueException.class, () -> new Heaplet().create(Name.of("test"),
+                    json(object(field("clientHandler", "idmClientHandler"))), heap), "/idmGetApiClientBaseUri: Expecting a value");
+        }
+
+        @Test
+        void successfullyCreatesFilter() throws Exception {
+            final HeapImpl heap = new HeapImpl(Name.of("heap"));
+            final Handler idmClientHandler = (ctx, req) -> Promises.newResultPromise(new Response(Status.OK));
+            heap.put("idmClientHandler", idmClientHandler);
+            final FetchApiClientFilter filter = (FetchApiClientFilter) new Heaplet().create(Name.of("test"),
+                    json(object(field("clientHandler", "idmClientHandler"), field("idmGetApiClientBaseUri", "http://idm"))), heap);
+        }
+    }
+
+    private static void verifyIdmClientDataMatchesApiClientObject(JsonValue idmClientData, ApiClient actualApiClient) {
+        assertEquals(idmClientData.get("id").asString(), actualApiClient.getSoftwareClientId());
+        assertEquals(idmClientData.get("name").asString(), actualApiClient.getClientName());
+        final String ssaStr = idmClientData.get("ssa").asString();
+        final SignedJwt expectedSignedJwt = new JwtReconstruction().reconstructJwt(ssaStr, SignedJwt.class);
+        assertEquals(expectedSignedJwt.getHeader(), actualApiClient.getSoftwareStatementAssertion().getHeader());
+        assertEquals(expectedSignedJwt.getClaimsSet(), actualApiClient.getSoftwareStatementAssertion().getClaimsSet());
+        assertEquals(idmClientData.get("oauth2ClientId").asString(), actualApiClient.getOauth2ClientId());
+        assertEquals(idmClientData.get("jwksUri").asString(), actualApiClient.getJwksUri().toString());
+        assertEquals(idmClientData.get("apiClientOrg").get("id").asString(), actualApiClient.getOrganisation().getId());
+        assertEquals(idmClientData.get("apiClientOrg").get("name").asString(), actualApiClient.getOrganisation().getName());
+    }
+
+    private static JsonValue createIdmApiClientData(String clientId) {
+        final JsonValue idmClientData = json(object(field("id", "ebSqTNqmQXFYz6VtWGXZAa"),
+                field("name", "Automated Testing"),
+                field("description", "Blah blah blah"),
+                field("ssa", createTestSoftwareStatementAssertion().build()),
+                field("oauth2ClientId", clientId),
+                field("jwksUri", "https://somelocation/jwks.jwks"),
+                field("apiClientOrg", object(field("id", "98761234"),
+                                             field("name", "Test Organisation")))));
+        return idmClientData;
+    }
+
+    /**
+     * @return SignedJwt which represents a Software Statement Assertion (ssa). This is a dummy JWT in place of a real
+     * software statement, it does not contain a realistic set of claims and the signature (and kid) are junk.
+     *
+     * This is good enough for this test as the ssa is not processed, only decoded into a SignedJwt object
+     */
+    private static SignedJwt createTestSoftwareStatementAssertion() {
+        final JwsHeader header = new JwsHeader();
+        header.setKeyId("12345");
+        header.setAlgorithm(JwsAlgorithm.PS256);
+        return new SignedJwt(header, new JwtClaimsSet(Map.of("claim1", "value1")), new SigningHandler() {
+            @Override
+            public byte[] sign(JwsAlgorithm algorithm, byte[] data) {
+                return "gYdMUpAvrotMnMP8tHj".getBytes(StandardCharsets.UTF_8);
+            }
+
+            @Override
+            public boolean verify(JwsAlgorithm algorithm, byte[] data, byte[] signature) {
+                return true;
+            }
+        });
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/FetchApiClientFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/FetchApiClientFilterTest.java
@@ -57,6 +57,12 @@ import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.dcr.FetchApiClientFilter.Heaplet;
 
+/**
+ * Unit tests for {@link FetchApiClientFilter}.
+ *
+ * IDM behaviour is simulated using Handlers installed as the httpClient within the Filter.
+ * See {@link MockApiClientTestDataIdmHandler} for an example Handler which returns mocked ApiClient data.
+ */
 class FetchApiClientFilterTest {
 
     @Test
@@ -74,7 +80,7 @@ class FetchApiClientFilterTest {
 
     @Test
     void failsWhenNoOAuth2ContextIsFound() {
-        final FetchApiClientFilter filter = new FetchApiClientFilter(new Client(Handlers.INTERNAL_SERVER_ERROR), "notUsed", "aud");
+        final FetchApiClientFilter filter = new FetchApiClientFilter(new Client(Handlers.FORBIDDEN), "notUsed", "aud");
         assertThrows(IllegalArgumentException.class, () -> filter.filter(new RootContext("root"), new Request(), Handlers.FORBIDDEN),
                 "No context of type org.forgerock.http.oauth2.OAuth2Context found");
     }
@@ -87,7 +93,6 @@ class FetchApiClientFilterTest {
 
         final Response response = responsePromise.get(1, TimeUnit.SECONDS);
         assertEquals(Status.INTERNAL_SERVER_ERROR, response.getStatus());
-        // FIXME improve assertion
     }
 
     @Test
@@ -101,7 +106,6 @@ class FetchApiClientFilterTest {
 
         final Response response = responsePromise.get(1, TimeUnit.SECONDS);
         assertEquals(Status.INTERNAL_SERVER_ERROR, response.getStatus());
-        // FIXME improve assertion
     }
 
     @Test
@@ -155,7 +159,6 @@ class FetchApiClientFilterTest {
             // optional config: accessTokenClientIdClaim will be defaulted to aud
             final AccessTokenInfo accessToken = createAccessToken("aud", clientId);
             // Test the filter created by the Heaplet
-
             callFilterValidateSuccessBehaviour(accessToken, idmApiClientData, filter);
         }
 
@@ -189,7 +192,7 @@ class FetchApiClientFilterTest {
      *
      * If the validation fails then a Runtime exception is returned, which will be thrown when Promise.get is called.
      */
-    private class MockApiClientTestDataIdmHandler implements Handler {
+    private static class MockApiClientTestDataIdmHandler implements Handler {
         private final MutableUri idmBaseUri;
         private final String expectedClientId;
         private final JsonValue staticApiClientData;
@@ -218,7 +221,7 @@ class FetchApiClientFilterTest {
     }
 
     private static void callFilterValidateSuccessBehaviour(AccessTokenInfo accessToken, JsonValue idmClientData,
-            FetchApiClientFilter filter) throws Exception {
+                                                           FetchApiClientFilter filter) throws Exception {
         final AttributesContext attributesContext = new AttributesContext(new RootContext("root"));
         final OAuth2Context oauth2Context = new OAuth2Context(attributesContext, accessToken);
 

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTestTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTestTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TrustedDirectoryOpenBankingTestTest {
+
+    TrustedDirectoryOpenBankingTest trustedDirectory = new TrustedDirectoryOpenBankingTest();
+
+    @Test
+    void testGetters(){
+        assertThat(trustedDirectory.getIssuer()).isEqualTo(TrustedDirectoryOpenBankingTest.issuer);
+        assertThat(trustedDirectory.getJwksUri()).isEqualTo(TrustedDirectoryOpenBankingTest.jwksUri);
+        assertThat(trustedDirectory.softwareStatementHoldsJwksUri()).isTrue();
+        assertThat(trustedDirectory.getSoftwareStatementJwksClaimName()).isNull();
+        assertThat(trustedDirectory.getSoftwareStatementJwksUriClaimName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareJwksUriClaimName);
+        assertThat(trustedDirectory.getSoftwareStatementOrgIdClaimName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareStatementOrgIdClaimName);
+        assertThat(trustedDirectory.getSoftwareStatementSoftwareIdClaimName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareStatementSoftwareIdClaimName);
+    }
+
+}

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGatewayTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGatewayTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TrustedDirectorySecureApiGatewayTest {
+
+    private static final String testDirectoryFQDN = "https://saig.bigbank.com/jwkms/apiclient/jwks";
+    TrustedDirectorySecureApiGateway trustedDirectory = new TrustedDirectorySecureApiGateway(testDirectoryFQDN);
+
+    @Test
+    void checkFieldValues() {
+        // Given
+        // When
+        // Then
+        assertThat(trustedDirectory.getIssuer()).isEqualTo(TrustedDirectorySecureApiGateway.issuer);
+        assertThat(trustedDirectory.getJwksUri()).isEqualTo(testDirectoryFQDN);
+        assertThat(trustedDirectory.softwareStatementHoldsJwksUri()).isFalse();
+        assertThat(trustedDirectory.getSoftwareStatementJwksUriClaimName()).isNull();
+        assertThat(trustedDirectory.getSoftwareStatementJwksClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementJwksClaimName);
+        assertThat(trustedDirectory.getSoftwareStatementOrgIdClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementOrgIdClaimName);
+        assertThat(trustedDirectory.getSoftwareStatementSoftwareIdClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementSoftwareIdClaimName);
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStaticTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStaticTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TrustedDirectoryServiceStaticTest {
+
+    @BeforeEach
+    void setUp() {
+
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void getTrustedDirectoryConfiguration_IGTestDirectoryEnabled() {
+        // Given
+        Boolean enableIGTestTrustedDirectory = true;
+        String testDirectoryFQDN = "https://sapi.bigbank.com/jwkms/apiclient/jwks";
+        TrustedDirectoryService trustedDirectoryService = new TrustedDirectoryServiceStatic(enableIGTestTrustedDirectory, testDirectoryFQDN);
+        // When
+        TrustedDirectory directoryConfig = trustedDirectoryService.getTrustedDirectoryConfiguration(TrustedDirectorySecureApiGateway.issuer);
+
+        // Then
+        assertThat(directoryConfig).isNotNull();
+        assertThat(directoryConfig.getIssuer()).isEqualTo(TrustedDirectorySecureApiGateway.issuer);
+        assertThat(directoryConfig.getJwksUri()).isEqualTo(testDirectoryFQDN);
+        assertThat(directoryConfig.softwareStatementHoldsJwksUri()).isEqualTo(false);
+        assertThat(directoryConfig.getSoftwareStatementJwksUriClaimName()).isNull();
+        assertThat(directoryConfig.getSoftwareStatementJwksClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementJwksClaimName);
+        assertThat(directoryConfig.getSoftwareStatementOrgIdClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementOrgIdClaimName);
+        assertThat(directoryConfig.getSoftwareStatementSoftwareIdClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementSoftwareIdClaimName);
+    }
+
+    @Test
+    void getTrustedDirectoryConfiguration_IGTestDirectoryNotEnabled() {
+        // Given
+        Boolean enableIGTestTrustedDirectory = false;
+        String testDirectoryFQDN = "https://ig.bigbank.com/jwkms/apiclient/jwks";
+        TrustedDirectoryService trustedDirectoryService = new TrustedDirectoryServiceStatic(enableIGTestTrustedDirectory, testDirectoryFQDN);
+        // When
+        TrustedDirectory directoryConfig = trustedDirectoryService.getTrustedDirectoryConfiguration(TrustedDirectorySecureApiGateway.issuer);
+
+        // Then
+        assertThat(directoryConfig).isNull();
+    }
+
+    @Test
+    void getTrustedDirectoryConfiguration_getOpenBankingTestTrustedDirectory(){
+        // Given
+        Boolean enableIGTestTrustedDirectory = false;
+        String testDirectoryFQDN = "https://ig.bigbank.com/jwkms/apiclient/jwks";
+        TrustedDirectoryService trustedDirectoryService = new TrustedDirectoryServiceStatic(enableIGTestTrustedDirectory, testDirectoryFQDN);
+        // When
+        TrustedDirectory directoryConfig = trustedDirectoryService.getTrustedDirectoryConfiguration(TrustedDirectoryOpenBankingTest.issuer);
+
+        // Then
+        assertThat(directoryConfig).isNotNull();
+        assertThat(directoryConfig.getIssuer()).isEqualTo(TrustedDirectoryOpenBankingTest.issuer);
+    }
+}


### PR DESCRIPTION
Added data model classes ApiClient and ApiClientOrganistation.

FetchApiClientFilter queries IDM for ApiClient data based on the client_id found in the OAuth2Context. The filter than adds the ApiClient as a context attribute so that it can be used by other filters. The groovy filters this can be accessed via `attributes.apiClient`

NOTE: As the filter depends on the OAuth2Context then it must be installed in the chain after a filter which adds this context, typically: OAuth2ResourceServerFilter.

Added the filter to payment routes and used it in ProcessDetachedSig script to simplify accessing the ApiClient data.

In future the filter will be added to more routes, and other filters within the payments route will use the data.

https://github.com/SecureApiGateway/SecureApiGateway/issues/729