### PR TITLE
729: Adding FetchTrustedDirectoryFilter

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -100,6 +100,32 @@
       "capture" : [ "response", "request" ]
     },
     {
+      "name": "FetchApiClientAndTrustedDirectoryDataChain",
+      "type": "ChainOfFilters",
+      "comment": "This filter chain will set the apiClient and trustedDirectory attributes in the context based on the client_id of the request",
+      "config" : {
+        "filters": [
+          {
+            "comment": "Add ApiClient data to the context attributes",
+            "name": "FetchApiClientFilter",
+            "type": "FetchApiClientFilter",
+            "config": {
+              "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
+              "clientHandler": "IDMClientHandler"
+            }
+          },
+          {
+            "comment": "Add TrustedDirectory configuration to the context attributes",
+            "name": "FetchTrustedDirectoryFilter",
+            "type": "FetchTrustedDirectoryFilter",
+            "config": {
+              "trustedDirectoryService": "TrustedDirectoriesService"
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "SBATFapiInteractionFilterChain",
       "type": "ChainOfFilters",
       "comment": "This filter chain will set the x-fapi-interaction-id (if not provided in the request), and also set the transaction context to the x-fapi-interaction-id value. This means that if the 'TransactionIdOutboundFilter' is specified on any handlers used by the chain the x-fapi-interaction-id value will be passed onward in the X-ForgeRock-TransactionId header",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -98,15 +98,7 @@
             }
           }
         },
-        {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
+        "FetchApiClientAndTrustedDirectoryDataChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -117,15 +117,7 @@
             }
           }
         },
-        {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
+        "FetchApiClientAndTrustedDirectoryDataChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -107,15 +107,7 @@
             }
           }
         },
-        {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
+        "FetchApiClientAndTrustedDirectoryDataChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -117,15 +117,7 @@
             }
           }
         },
-        {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
+        "FetchApiClientAndTrustedDirectoryDataChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -99,15 +99,7 @@
             }
           }
         },
-        {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
+        "FetchApiClientAndTrustedDirectoryDataChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -117,15 +117,7 @@
             }
           }
         },
-        {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
+        "FetchApiClientAndTrustedDirectoryDataChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -98,15 +98,7 @@
             }
           }
         },
-        {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
+        "FetchApiClientAndTrustedDirectoryDataChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -117,15 +117,7 @@
             }
           }
         },
-        {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
+        "FetchApiClientAndTrustedDirectoryDataChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -98,15 +98,7 @@
             }
           }
         },
-        {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
+        "FetchApiClientAndTrustedDirectoryDataChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -117,15 +117,7 @@
             }
           }
         },
-        {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
+        "FetchApiClientAndTrustedDirectoryDataChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -98,15 +98,7 @@
             }
           }
         },
-        {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
+        "FetchApiClientAndTrustedDirectoryDataChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -117,15 +117,7 @@
             }
           }
         },
-        {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
+        "FetchApiClientAndTrustedDirectoryDataChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -98,15 +98,7 @@
             }
           }
         },
-        {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
+        "FetchApiClientAndTrustedDirectoryDataChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
@@ -97,15 +97,7 @@
             }
           }
         },
-        {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
+        "FetchApiClientAndTrustedDirectoryDataChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -117,15 +117,7 @@
             }
           }
         },
-        {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
+        "FetchApiClientAndTrustedDirectoryDataChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -98,15 +98,7 @@
             }
           }
         },
-        {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
+        "FetchApiClientAndTrustedDirectoryDataChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -117,15 +117,7 @@
             }
           }
         },
-        {
-          "comment": "Add ApiClient data to the context attributes",
-          "name": "FetchApiClientFilter",
-          "type": "FetchApiClientFilter",
-          "config": {
-            "idmGetApiClientBaseUri": "&{urls.idmGetApiClientBaseUri}",
-            "clientHandler": "IDMClientHandler"
-          }
-        },
+        "FetchApiClientAndTrustedDirectoryDataChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
@@ -25,6 +25,7 @@ import com.forgerock.sapi.gateway.fapi.v1.FAPIAdvancedDCRValidationFilter;
 import com.forgerock.sapi.gateway.jwks.RestJwkSetService;
 import com.forgerock.sapi.gateway.jwks.cache.caffeine.CaffeineCachingJwkSetService;
 import com.forgerock.sapi.gateway.jws.RsaJwtSignatureValidator;
+import com.forgerock.sapi.gateway.trusteddirectories.FetchTrustedDirectoryFilter;
 import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectoryService;
 
 public class SecureApiGatewayClassAliasResolver implements ClassAliasResolver {
@@ -37,6 +38,7 @@ public class SecureApiGatewayClassAliasResolver implements ClassAliasResolver {
         ALIASES.put("RsaJwtSignatureValidator", RsaJwtSignatureValidator.class);
         ALIASES.put("TrustedDirectoriesService", TrustedDirectoryService.class);
         ALIASES.put("FetchApiClientFilter", FetchApiClientFilter.class);
+        ALIASES.put("FetchTrustedDirectoryFilter", FetchTrustedDirectoryFilter.class);
     }
 
     /**

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/FetchApiClientFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/FetchApiClientFilter.java
@@ -83,6 +83,18 @@ public class FetchApiClientFilter implements Filter {
      */
     private final String accessTokenClientIdClaim;
 
+    /**
+     * Utility method to retrieve an ApiClient object from a Context.
+     * This method can be used by other filters to retrieve the ApiClient installed into the attributes context by
+     * this filter.
+     *
+     * @param context the context to retrieve the ApiClient from
+     * @return the ApiClient or null if it is not set in the context.
+     */
+    public static ApiClient getApiClientFromContext(Context context) {
+        return (ApiClient) context.asContext(AttributesContext.class).getAttributes().get(API_CLIENT_ATTR_KEY);
+    }
+
     public FetchApiClientFilter(Client clientHandler, String idmGetApiClientBaseUri, String accessTokenClientIdClaim) {
         Reject.ifNull(clientHandler, "clientHandler must be provided");
         Reject.ifBlank(idmGetApiClientBaseUri, "idmGetApiClientBaseUri must be provided");

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/idm/IdmApiClientDecoder.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/idm/IdmApiClientDecoder.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.dcr.idm;
+
+import java.net.URI;
+
+import org.forgerock.json.JsonValue;
+import org.forgerock.json.JsonValueException;
+import org.forgerock.json.jose.common.JwtReconstruction;
+import org.forgerock.json.jose.jws.SignedJwt;
+
+import com.forgerock.sapi.gateway.dcr.ApiClient;
+import com.forgerock.sapi.gateway.dcr.ApiClientOrganisation;
+
+/**
+ * Decodes an {@link ApiClient} from a {@link JsonValue} returned by IDM
+ */
+public class IdmApiClientDecoder {
+
+    /**
+     * Decodes a json into an ApiClient.
+     *
+     * This method will throw a RuntimeException if decoding fails, for example if a required field is missing or if
+     * there is a datatype mismatch.
+     *
+     * @param apiClientJson the json to decode
+     * @return ApiClient
+     * @throws JsonValueException
+     */
+    public ApiClient decode(JsonValue apiClientJson) {
+        try {
+            final ApiClient apiClient = new ApiClient();
+            apiClient.setClientName(apiClientJson.get("name").as(this::requiredField).asString());
+            apiClient.setOauth2ClientId(apiClientJson.get("oauth2ClientId").as(this::requiredField).asString());
+            apiClient.setSoftwareClientId(apiClientJson.get("id").as(this::requiredField).asString());
+
+            apiClient.setSoftwareStatementAssertion(apiClientJson.get("ssa").as(this::requiredField).as(
+                    ssa -> {
+                        final String jwtString = ssa.asString();
+                        try {
+                            return new JwtReconstruction().reconstructJwt(jwtString, SignedJwt.class);
+                        } catch (RuntimeException rte) {
+                            throw new JsonValueException(ssa, "failed to decode JWT, raw jwt string: " + jwtString, rte);
+                        }
+                    }));
+
+            apiClient.setOrganisation(apiClientJson.get("apiClientOrg").as(this::requiredField).as(org -> {
+                final JsonValue orgJson = JsonValue.json(org);
+                final String orgId = orgJson.get("id").asString();
+                final String orgName = orgJson.get("name").asString();
+                return new ApiClientOrganisation(orgId, orgName);
+            }));
+
+            final JsonValue jwksUri = apiClientJson.get("jwksUri");
+            if (jwksUri.isNotNull()) {
+                apiClient.setJwksUri(jwksUri.as(jwks -> URI.create(jwks.asString())));
+            }
+            return apiClient;
+        } catch (JsonValueException jve) {
+            // These errors are expected and contain enough information to understand what when wrong e.g. missing required field
+            throw jve;
+        } catch (RuntimeException ex) {
+            // Unexpected decode exception, dump the raw json to provide additional debug info
+            throw new IllegalStateException("Unexpected exception thrown decoding apiClient, raw json: " + apiClientJson, ex);
+        }
+    }
+
+    /**
+     * Helper transformationFunction which validates that a particular field has a value.
+     * If the field is null then a JsonValueException will be raised.
+     */
+    private JsonValue requiredField(JsonValue jsonValue) throws JsonValueException {
+        if (jsonValue.isNull()) {
+            throw new JsonValueException(jsonValue, "is a required field, failed to decode IDM ApiClient");
+        }
+        return jsonValue;
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/FetchTrustedDirectoryFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/FetchTrustedDirectoryFilter.java
@@ -44,6 +44,9 @@ import com.forgerock.sapi.gateway.fapi.FAPIUtils;
  */
 public class FetchTrustedDirectoryFilter implements Filter {
 
+    /**
+     * The key to use to get the TrustedDirectory from the AttributesContext
+     */
     public static final String TRUSTED_DIRECTORY_ATTR_KEY = "trustedDirectory";
 
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/FetchTrustedDirectoryFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/FetchTrustedDirectoryFilter.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+import static org.forgerock.openig.util.JsonValues.requiredHeapObject;
+
+import org.forgerock.http.Filter;
+import org.forgerock.http.Handler;
+import org.forgerock.http.protocol.Request;
+import org.forgerock.http.protocol.Response;
+import org.forgerock.json.jose.jwt.JwtClaimsSet;
+import org.forgerock.openig.heap.GenericHeaplet;
+import org.forgerock.openig.heap.HeapException;
+import org.forgerock.services.context.AttributesContext;
+import org.forgerock.services.context.Context;
+import org.forgerock.util.Reject;
+import org.forgerock.util.promise.NeverThrowsException;
+import org.forgerock.util.promise.Promise;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.forgerock.sapi.gateway.dcr.ApiClient;
+import com.forgerock.sapi.gateway.dcr.FetchApiClientFilter;
+import com.forgerock.sapi.gateway.fapi.FAPIUtils;
+
+/**
+ * Fetches {@link TrustedDirectory} configuration for the {@link ApiClient} that is configured in the {@link AttributesContext}
+ * and adds the TrustedDirectory to the attributes context so that it can be used by subsequent filters.
+ *
+ * This filter must be installed after a filter which adds the ApiClient to the context, typically: {@link FetchApiClientFilter}
+ */
+public class FetchTrustedDirectoryFilter implements Filter {
+
+    public static final String TRUSTED_DIRECTORY_ATTR_KEY = "trustedDirectory";
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    /**
+     * The Service used to retrieve the TrustedDirectory
+     */
+    private final TrustedDirectoryService trustedDirectoryService;
+
+    /**
+     * Utility method to retrieve a TrustedDirectory object from a Context.
+     * This method can be used by other filters to retrieve the TrustedDirectory installed into the attributes context by
+     * this filter.
+     *
+     * @param context the context to retrieve the TrustedDirectory from
+     * @return the TrustedDirectory or null if it is not set in the context.
+     */
+    public static TrustedDirectory getTrustedDirectoryFromContext(Context context) {
+        return (TrustedDirectory) context.asContext(AttributesContext.class).getAttributes().get(TRUSTED_DIRECTORY_ATTR_KEY);
+    }
+
+    public FetchTrustedDirectoryFilter(TrustedDirectoryService trustedDirectoryService) {
+        Reject.ifNull(trustedDirectoryService, "trustedDirectoryService must be provided");
+        this.trustedDirectoryService = trustedDirectoryService;
+    }
+
+    @Override
+    public Promise<Response, NeverThrowsException> filter(Context context, Request request, Handler next) {
+        final ApiClient apiClient = FetchApiClientFilter.getApiClientFromContext(context);
+        if (apiClient == null) {
+            logger.error("({}) apiClient not found in request context", FAPIUtils.getFapiInteractionIdForDisplay(context));
+            throw new IllegalStateException("apiClient not found in request context");
+        }
+        try {
+            context.asContext(AttributesContext.class).getAttributes().put(TRUSTED_DIRECTORY_ATTR_KEY, getTrustedDirectory(apiClient));
+            return next.handle(context, request);
+        } catch (RuntimeException ex) {
+            logger.error("(" + FAPIUtils.getFapiInteractionIdForDisplay(context) + ") failed to get trustedDirectory for apiClient: " + apiClient, ex);
+            throw ex;
+        }
+    }
+
+    private TrustedDirectory getTrustedDirectory(ApiClient apiClient) {
+        final JwtClaimsSet ssaClaims = apiClient.getSoftwareStatementAssertion().getClaimsSet();
+        final String issuer = ssaClaims.getIssuer();
+        final TrustedDirectory trustedDirectory = trustedDirectoryService.getTrustedDirectoryConfiguration(issuer);
+        if (trustedDirectory == null) {
+            throw new IllegalStateException("Failed to get trusted directory for ssa issuer: " + issuer);
+        }
+        return trustedDirectory;
+    }
+
+    /**
+     * Responsible for creating the {@link FetchTrustedDirectoryFilter}
+     *
+     * Mandatory config:
+     * - trustedDirectoryService: the name of a {@link TrustedDirectoryService} object on the heap
+     *
+     * Example config:
+     * {
+     *             "comment": "Add TrustedDirectory configuration to the context attributes",
+     *             "name": "FetchTrustedDirectoryFilter",
+     *             "type": "FetchTrustedDirectoryFilter",
+     *             "config": {
+     *               "trustedDirectoryService": "TrustedDirectoriesService"
+     *             }
+     * }
+     */
+    public static class Heaplet extends GenericHeaplet {
+        @Override
+        public Object create() throws HeapException {
+            final TrustedDirectoryService trustedDirectoryService = config.get("trustedDirectoryService")
+                    .as(requiredHeapObject(heap, TrustedDirectoryService.class));
+
+            return new FetchTrustedDirectoryFilter(trustedDirectoryService);
+        }
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/FetchApiClientFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/FetchApiClientFilterTest.java
@@ -244,7 +244,7 @@ class FetchApiClientFilterTest {
             assertEquals(Status.NO_CONTENT, response.getStatus());
 
             // Verify that the context was updated with the apiClient data
-            final ApiClient apiClient = (ApiClient) ctxt.getAttributes().get(API_CLIENT_ATTR_KEY);
+            final ApiClient apiClient = FetchApiClientFilter.getApiClientFromContext(ctxt);
             assertNotNull(apiClient, "apiClient was not found in context");
             verifyIdmClientDataMatchesApiClientObject(idmClientData, apiClient);
         };

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/idm/IdmApiClientDecoderTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/idm/IdmApiClientDecoderTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.dcr.idm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.json.JsonValue.field;
+import static org.forgerock.json.JsonValue.json;
+import static org.forgerock.json.JsonValue.object;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.forgerock.json.JsonValue;
+import org.forgerock.json.JsonValueException;
+import org.forgerock.json.jose.common.JwtReconstruction;
+import org.forgerock.json.jose.exceptions.InvalidJwtException;
+import org.forgerock.json.jose.jws.JwsAlgorithm;
+import org.forgerock.json.jose.jws.JwsHeader;
+import org.forgerock.json.jose.jws.SignedJwt;
+import org.forgerock.json.jose.jws.handlers.SigningHandler;
+import org.forgerock.json.jose.jwt.JwtClaimsSet;
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.dcr.ApiClient;
+
+public class IdmApiClientDecoderTest {
+
+    private final IdmApiClientDecoder idmApiClientDecoder = new IdmApiClientDecoder();
+
+    public static JsonValue createIdmApiClientDataAllFields(String clientId) {
+        return createIdmApiClientDataRequiredFieldsOnly(clientId).put("jwksUri", "https://somelocation/jwks.jwks");
+    }
+
+    public static JsonValue createIdmApiClientDataRequiredFieldsOnly(String clientId) {
+        return json(object(field("id", "ebSqTNqmQXFYz6VtWGXZAa"),
+                field("name", "Automated Testing"),
+                field("description", "Blah blah blah"),
+                field("ssa", createTestSoftwareStatementAssertion().build()),
+                field("oauth2ClientId", clientId),
+                field("apiClientOrg", object(field("id", "98761234"),
+                        field("name", "Test Organisation")))));
+    }
+
+    /**
+     * @return SignedJwt which represents a Software Statement Assertion (ssa). This is a dummy JWT in place of a real
+     * software statement, it does not contain a realistic set of claims and the signature (and kid) are junk.
+     *
+     * This is good enough for this test as the ssa is not processed, only decoded into a SignedJwt object
+     */
+    private static SignedJwt createTestSoftwareStatementAssertion() {
+        final JwsHeader header = new JwsHeader();
+        header.setKeyId("12345");
+        header.setAlgorithm(JwsAlgorithm.PS256);
+        return new SignedJwt(header, new JwtClaimsSet(Map.of("claim1", "value1")), new SigningHandler() {
+            @Override
+            public byte[] sign(JwsAlgorithm algorithm, byte[] data) {
+                return "gYdMUpAvrotMnMP8tHj".getBytes(StandardCharsets.UTF_8);
+            }
+
+            @Override
+            public boolean verify(JwsAlgorithm algorithm, byte[] data, byte[] signature) {
+                return false;
+            }
+        });
+    }
+
+    public static void verifyIdmClientDataMatchesApiClientObject(JsonValue idmClientData, ApiClient actualApiClient) {
+        assertEquals(idmClientData.get("id").asString(), actualApiClient.getSoftwareClientId());
+        assertEquals(idmClientData.get("name").asString(), actualApiClient.getClientName());
+        assertEquals(idmClientData.get("oauth2ClientId").asString(), actualApiClient.getOauth2ClientId());
+        final JsonValue jwksUri = idmClientData.get("jwksUri");
+        if (jwksUri.isNotNull()) {
+            assertEquals(jwksUri.asString(), actualApiClient.getJwksUri().toString());
+        }
+        assertEquals(idmClientData.get("apiClientOrg").get("id").asString(), actualApiClient.getOrganisation().getId());
+        assertEquals(idmClientData.get("apiClientOrg").get("name").asString(), actualApiClient.getOrganisation().getName());
+
+        final String ssaStr = idmClientData.get("ssa").asString();
+        final SignedJwt expectedSignedJwt = new JwtReconstruction().reconstructJwt(ssaStr, SignedJwt.class);
+        assertEquals(expectedSignedJwt.getHeader(), actualApiClient.getSoftwareStatementAssertion().getHeader());
+        assertEquals(expectedSignedJwt.getClaimsSet(), actualApiClient.getSoftwareStatementAssertion().getClaimsSet());
+    }
+
+    @Test
+    void decodeApiClientAllFieldsSet() {
+        final JsonValue idmJson = createIdmApiClientDataAllFields("1234");
+        final ApiClient apiClient = new IdmApiClientDecoder().decode(idmJson);
+        verifyIdmClientDataMatchesApiClientObject(idmJson, apiClient);
+    }
+
+    @Test
+    void decodeApiClientRequiredFieldsOnly() {
+        final JsonValue idmJson = createIdmApiClientDataRequiredFieldsOnly("9999");
+        final ApiClient apiClient = idmApiClientDecoder.decode(idmJson);
+        verifyIdmClientDataMatchesApiClientObject(idmJson, apiClient);
+        assertNull(apiClient.getJwksUri(), "jwksUri must be null");
+    }
+
+    @Test
+    void failToDecodeMissingMandatoryFields() {
+        JsonValueException decodeException = assertThrows(JsonValueException.class,
+                () -> idmApiClientDecoder.decode(json(object())));
+        assertEquals("/name: is a required field, failed to decode IDM ApiClient", decodeException.getMessage());
+
+        final JsonValue missingSsaField = createIdmApiClientDataRequiredFieldsOnly("123454");
+        missingSsaField.remove("ssa");
+
+        decodeException = assertThrows(JsonValueException.class, () -> idmApiClientDecoder.decode(missingSsaField));
+        assertEquals("/ssa: is a required field, failed to decode IDM ApiClient", decodeException.getMessage());
+    }
+
+    @Test
+    void failToDecodeDueToUnexpectedException() {
+        final JsonValue corruptSsaField = createIdmApiClientDataRequiredFieldsOnly("123454");
+        corruptSsaField.put("ssa", "This is not a JWT");
+
+        JsonValueException decodeException = assertThrows(JsonValueException.class, () -> idmApiClientDecoder.decode(corruptSsaField));
+        assertEquals("/ssa: failed to decode JWT, raw jwt string: This is not a JWT", decodeException.getMessage());
+        assertThat(decodeException.getCause()).isInstanceOf(InvalidJwtException.class);
+        decodeException.getCause().printStackTrace();
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/FetchTrustedDirectoryFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/FetchTrustedDirectoryFilterTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.trusteddirectories;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.json.JsonValue.field;
+import static org.forgerock.json.JsonValue.json;
+import static org.forgerock.json.JsonValue.object;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.forgerock.http.protocol.Request;
+import org.forgerock.json.JsonValue;
+import org.forgerock.json.jose.jws.JwsHeader;
+import org.forgerock.json.jose.jws.SignedJwt;
+import org.forgerock.json.jose.jwt.JwtClaimsSet;
+import org.forgerock.openig.heap.HeapException;
+import org.forgerock.openig.heap.HeapImpl;
+import org.forgerock.openig.heap.Name;
+import org.forgerock.services.context.AttributesContext;
+import org.forgerock.services.context.Context;
+import org.forgerock.services.context.RootContext;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.dcr.ApiClient;
+import com.forgerock.sapi.gateway.dcr.FetchApiClientFilter;
+import com.forgerock.sapi.gateway.trusteddirectories.FetchTrustedDirectoryFilter.Heaplet;
+import com.forgerock.sapi.gateway.util.TestHandlers.TestSuccessResponseHandler;
+
+class FetchTrustedDirectoryFilterTest {
+
+    private final TrustedDirectoryService trustedDirectoryService =  new TrustedDirectoryServiceStatic(true, "https://test-bank.com");
+
+    private static ApiClient createApiClient(String issuer) {
+        final JwtClaimsSet ssaClaims = new JwtClaimsSet();
+        ssaClaims.setIssuer(issuer);
+        final SignedJwt ssaSignedJwt = new SignedJwt(new JwsHeader(), ssaClaims, new byte[0], new byte[0]);
+
+        final ApiClient apiClient = new ApiClient();
+        apiClient.setSoftwareStatementAssertion(ssaSignedJwt);
+        return apiClient;
+    }
+
+    @Test
+    void testTrustedDirectoryIsAddedToContext() {
+        final FetchTrustedDirectoryFilter filter = new FetchTrustedDirectoryFilter(trustedDirectoryService);
+        testFetchingOpenBankingTestIssuer(filter);
+    }
+
+    private void testFetchingOpenBankingTestIssuer(FetchTrustedDirectoryFilter filter) {
+        final Context rootContext = new RootContext("root");
+        final AttributesContext attributesContext = new AttributesContext(rootContext);
+        final ApiClient apiClient = createApiClient(TrustedDirectoryOpenBankingTest.issuer);
+        attributesContext.getAttributes().put(FetchApiClientFilter.API_CLIENT_ATTR_KEY, apiClient);
+
+        callFilterAndValidateSuccessResponse(filter, attributesContext);
+    }
+
+    @Test
+    void failsIfApiClientNotFound() {
+        final IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> callFilterAndValidateSuccessResponse(new FetchTrustedDirectoryFilter(trustedDirectoryService), new AttributesContext(new RootContext("root"))));
+
+        assertThat(exception.getMessage()).contains("apiClient not found in request context");
+    }
+
+    @Test
+    void failsIfTrustedDirectoryDoesNotExistForIssuer() {
+        final Context rootContext = new RootContext("root");
+        final AttributesContext attributesContext = new AttributesContext(rootContext);
+        final ApiClient apiClient = createApiClient("ACME Bank");
+        attributesContext.getAttributes().put(FetchApiClientFilter.API_CLIENT_ATTR_KEY, apiClient);
+
+        final IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> callFilterAndValidateSuccessResponse(new FetchTrustedDirectoryFilter(trustedDirectoryService), attributesContext));
+
+        assertThat(exception.getMessage()).isEqualTo("Failed to get trusted directory for ssa issuer: ACME Bank");
+    }
+
+    @Nested
+    class HeapletTests {
+        @Test
+        void testFilterCreatedByHeaplet() throws Exception {
+            final HeapImpl heap = new HeapImpl(Name.of("heap"));
+            heap.put("trustedDirectoryService", trustedDirectoryService);
+
+            final JsonValue config = json(object(field("trustedDirectoryService", "trustedDirectoryService")));
+            final FetchTrustedDirectoryFilter filter = (FetchTrustedDirectoryFilter) new Heaplet().create(Name.of("test"), config, heap);
+            testFetchingOpenBankingTestIssuer(filter);
+        }
+
+        @Test
+        void failToCreateFilterWhenTrustedDirectoryConfigIsMissing() {
+            final HeapImpl heap = new HeapImpl(Name.of("heap"));
+            final JsonValue config = json(object());
+            final HeapException heapException = assertThrows(HeapException.class, () -> new Heaplet().create(Name.of("test"), config, heap));
+            assertEquals("/trustedDirectoryService: Expecting a value", heapException.getCause().getMessage());
+        }
+    }
+
+    private void callFilterAndValidateSuccessResponse(FetchTrustedDirectoryFilter filter, Context context) {
+        assertNull(FetchTrustedDirectoryFilter.getTrustedDirectoryFromContext(context),
+                "There must be no TrustedDirectory in the context prior to the test running");
+
+        final TestSuccessResponseHandler successResponseHandler = new TestSuccessResponseHandler();
+        filter.filter(context, new Request(), successResponseHandler);
+
+        final TrustedDirectory trustedDirectory = FetchTrustedDirectoryFilter.getTrustedDirectoryFromContext(context);
+        assertEquals(TrustedDirectoryOpenBankingTest.issuer, trustedDirectory.getIssuer());
+        assertTrue(successResponseHandler.hasBeenInteractedWith(), "Expected filter to pass request on to the successResponseHandler");
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/util/TestHandlers.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/util/TestHandlers.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.util;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.forgerock.http.Handler;
+import org.forgerock.http.protocol.Request;
+import org.forgerock.http.protocol.Response;
+import org.forgerock.http.protocol.Status;
+import org.forgerock.services.context.Context;
+import org.forgerock.util.promise.NeverThrowsException;
+import org.forgerock.util.promise.Promise;
+import org.forgerock.util.promise.Promises;
+
+/**
+ * Collection of {@link Handler} implementations which are useful for testing purposes
+ */
+public class TestHandlers {
+
+    /**
+     * Handler which counts the number of times the handle method is invoked. This is useful to verify that a filter
+     * passed a request on to another handler.
+     *
+     * This handler delegates to another handler for the actual impl.
+     */
+    public static class TestHandler implements Handler {
+        private final Handler delegateHandler;
+        private final AtomicInteger numInteractions = new AtomicInteger();
+
+        public TestHandler(Handler delegateHandler) {
+            this.delegateHandler = delegateHandler;
+        }
+
+        @Override
+        public Promise<Response, NeverThrowsException> handle(Context context, Request request) {
+            numInteractions.incrementAndGet();
+            return delegateHandler.handle(context, request);
+        }
+
+        public int getNumInteractions() {
+            return numInteractions.get();
+        }
+
+        public boolean hasBeenInteractedWith() {
+            return getNumInteractions() > 0;
+        }
+    }
+
+    /**
+     * Handler which always returns a 200 response.
+     */
+    public static class TestSuccessResponseHandler extends TestHandler {
+        public TestSuccessResponseHandler() {
+            super((ctxt, req) -> Promises.newResultPromise(new Response(Status.OK)));
+        }
+    }
+}


### PR DESCRIPTION
This filter will add the TrustedDirectory for this ApiClient to the attributes context. NOTE: FetchTrustedDirectoryFilter should be installed in a filter chain after the FetchApiClientFilter filter, as the ApiClient data is required to determine the TrustedDirectory.

Added filter chain: FetchApiClientAndTrustedDirectoryDataChain which can be used to fetch the ApiClient and then the TrustedDirectory. Updating existing usages of the FetchApiClientFilter in routes to use the new chain.

https://github.com/SecureApiGateway/SecureApiGateway/issues/729