### PR TITLE
773: process registration should not rely on certificate

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -395,6 +395,7 @@
       "name": "OBJwkSetService",
       "type": "CaffeineCachingJwkSetService",
       "config": {
+        "handler": "OBClientHandler",
         "maxCacheEntries": 500,
         "expireAfterWriteDuration": "24 hours"
       }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -64,7 +64,8 @@
               "jwkSetService": "${heap['OBJwkSetService']}",
               "allowIgIssuedTestCerts": "${security.allowIgIssuedTestCerts}",
               "jwtSignatureValidator": "${heap['RsaJwtSignatureValidator']}",
-              "tokenEndpointAuthMethodsSupported": "${oauth2.tokenEndpointAuthMethodsSupported}"
+              "tokenEndpointAuthMethodsSupported": "${oauth2.tokenEndpointAuthMethodsSupported}",
+              "trustedDirectoryService": "${heap['TrustedDirectoriesService']}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
@@ -152,7 +152,7 @@ def buildApiClientIdmObject(oauth2ClientId, ssaClaims) {
   def clientJwks = attributes.registrationJWTs.registrationJwks
   def apiClientIdmObj = [
           "_id"           : oauth2ClientId,
-          "id"            : ssaClaims.getClaim("software_client_id"),
+          "id"            : ssaClaims.getClaim("software_id"),
           "name"          : ssaClaims.getClaim("software_client_name"),
           "description"   : ssaClaims.getClaim("software_client_description"),
           "ssa"           : attributes.registrationJWTs.ssaStr,

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -56,7 +56,7 @@ def errorResponseFactory = new ErrorResponseFactory(SCRIPT_NAME)
 def defaultResponseTypes =  ["code id_token"]
 def supportedResponseTypes = [defaultResponseTypes]
 
-if(trustedDirectoryService == null) {
+if(!trustedDirectoryService) {
     logger.error(SCRIPT_NAME + "No TrustedDirectoriesService defined on the heap in config.json")
     return new Response(Status.INTERNAL_SERVER_ERROR).body("No TrustedDirectoriesService defined on the heap in config.json")
 }
@@ -113,10 +113,18 @@ switch(method.toUpperCase()) {
         // rejected by AM. This is set to change when OBIE release a new version of the Directory in Feb 2023.
         registrationJwtClaimSet.setClaim("software_statement", null);
 
-        String ssaIssuer = registrationJwtClaimSet.getIssuer()
-        if(issuer == null || issuer.isBlank()){
+        Jwt ssaJwt = JwtUtils.getSignedJwtFromString(SCRIPT_NAME, ssa, "SSA")
+        if (!ssaJwt) {
+            logger.warn(SCRIPT_NAME + "failed to decode software_statement JWT", e)
+            return errorResponseFactory.invalidSoftwareStatementErrorResponse("software_statement is not a valid JWT")
+        }
+
+        def ssaClaims = ssaJwt.getClaimsSet();
+        String ssaIssuer = ssaClaims.getIssuer()
+        if(ssaIssuer == null || ssaIssuer.isBlank()){
             return errorResponseFactory.invalidClientMetadataErrorResponse("Registration jwt must contain an issuer")
         }
+        logger.debug(SCRIPT_NAME + "issuer is {}", ssaIssuer)
 
         TrustedDirectory trustedDirectory = trustedDirectoryService.getTrustedDirectoryConfiguration(ssaIssuer)
         if(trustedDirectory){
@@ -125,14 +133,6 @@ switch(method.toUpperCase()) {
             logger.debug(SCRIPT_NAME + "Could not find Trusted Directory for issuer '" + ssaIssuer + "'")
             return errorResponseFactory.invalidSoftwareStatementErrorResponse("issuer: " + ssaIssuer + " is not supported")
         }
-
-        Jwt ssaJwt = JwtUtils.getSignedJwtFromString(SCRIPT_NAME, ssa, "SSA")
-        if (!ssaJwt) {
-            logger.warn(SCRIPT_NAME + "failed to decode software_statement JWT", e)
-            return errorResponseFactory.invalidSoftwareStatementErrorResponse("software_statement is not a valid JWT")
-        }
-
-        def ssaClaims = ssaJwt.getClaimsSet();
 
         try {
             validateRegistrationRedirectUris(registrationJwtClaimSet, ssaClaims)
@@ -153,13 +153,9 @@ switch(method.toUpperCase()) {
         def apiClientOrgName = ssaClaims.getClaim("software_client_name", String.class);
         def apiClientOrgCertId = ssaClaims.getClaim(trustedDirectory.getSoftwareStatementOrgIdClaimName(), String.class);
 
-
-
-        logger.debug(SCRIPT_NAME + "Inbound details from SSA: apiClientOrgName: {} apiClientOrgCertId: {} apiClientOrgJwksUri: {} apiClientOrgJwks: {}",
+        logger.debug(SCRIPT_NAME + "Inbound details from SSA: apiClientOrgName: {} apiClientOrgCertId: {}",
                 apiClientOrgName,
-                apiClientOrgCertId,
-                apiClientOrgJwksUri,
-                apiClientOrgJwks
+                apiClientOrgCertId
         )
 
         // Update OIDC registration request

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -240,13 +240,15 @@ switch (method.toUpperCase()) {
             // Verify against the software_jwks which is a JWKSet embedded within the software_statement
             // NOTE: this is only suitable for developer testing purposes
             if (!allowIgIssuedTestCerts) {
-                return errorResponseFactory.invalidSoftwareStatementErrorResponse("software_statement must contain software_jwks_endpoint")
+                String errorDescription = "software_statement must contain software_jwks_endpoint"
+                return errorResponseFactory.invalidSoftwareStatementErrorResponse(errorDescription)
             }
             def apiClientOrgJwks = registrationJWTs["registrationJwks"]
             logger.debug(SCRIPT_NAME + "Checking cert against ssa software_jwks: " + apiClientOrgJwks)
             def jwkSet = new JWKSet(new JsonValue(apiClientOrgJwks.get("keys")))
             if (!tlsClientCertExistsInJwkSet(jwkSet)) {
-                String errorDescription = "tls transport cert does not match any certs registered in jwks for software statement"
+                String errorDescription = "tls transport cert does not match any certs registered in jwks for software " +
+                        "statement"
                 logger.debug("{}{}", SCRIPT_NAME, errorDescription)
                 return newResultPromise(errorResponseFactory.invalidSoftwareStatementErrorResponse(errorDescription))
             }
@@ -374,9 +376,10 @@ private boolean tlsClientCertExistsInJwkSet(jwkSet) {
         final List<String> x509Chain = jwk.getX509Chain();
         final String jwkX5c = x509Chain.get(0);
         if ("tls".equals(jwk.getUse()) && tlsClientCertX5c.equals(jwkX5c)) {
-            logger.debug(SCRIPT_NAME + "Found matching tls cert for provided pem, with kid: " + jwk.getKeyId() + " x5t#S256: " + jwk.getX509ThumbprintS256())
+            logger.debug(SCRIPT_NAME + "Found matching tls cert for provided pem, with kid: " + jwk.getKeyId()
+                    + " x5t#S256: " + jwk.getX509ThumbprintS256())
             return true
-        } 
+        }
     }
     logger.debug(SCRIPT_NAME + "tls transport cert does not match any certs registered in jwks for software statement")
     return false

--- a/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
@@ -58,7 +58,7 @@ switch(method.toUpperCase()) {
             return errorResponseFactory.invalidSoftwareStatementErrorResponse("issuer: " + ssaIssuer + " is not supported")
         }
 
-        def ssaJwksUrl = trustedDirectory.getJwksUri()
+        def ssaJwksUrl = trustedDirectory.getDirectoryJwksUri()
         if (!ssaJwksUrl) {
             return errorResponseFactory.invalidSoftwareStatementErrorResponse("issuer: " + ssaIssuer + " is not supported")
         }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/com/securebanking/gateway/dcr/ErrorResponseFactory.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/com/securebanking/gateway/dcr/ErrorResponseFactory.groovy
@@ -11,6 +11,10 @@ import org.slf4j.LoggerFactory
  */
 class ErrorResponseFactory {
 
+    static String INVALID_CLIENT_METADATA_ERROR_CODE = "invalid_client_metadata"
+    static String INVALID_SOFTWARE_STATEMENT_ERROR_CODE = "invalid_software_statement"
+    static String INVALID_REDIRECT_URI_ERROR_CODE = "invalid_redirect_uri"
+
     private final Logger logger = LoggerFactory.getLogger(getClass())
     /**
      * Prefix for log messages created by this factory.
@@ -23,22 +27,22 @@ class ErrorResponseFactory {
     }
 
     def invalidClientMetadataErrorResponse(errorMessage) {
-        return errorResponse(Status.BAD_REQUEST, "invalid_client_metadata", errorMessage)
+        return errorResponse(Status.BAD_REQUEST, INVALID_CLIENT_METADATA_ERROR_CODE, errorMessage)
     }
 
     def invalidSoftwareStatementErrorResponse(errorMessage) {
-        return errorResponse(Status.BAD_REQUEST, "invalid_software_statement", errorMessage)
+        return errorResponse(Status.BAD_REQUEST, INVALID_SOFTWARE_STATEMENT_ERROR_CODE, errorMessage)
     }
 
     def invalidRedirectUriErrorResponse(errorMessage) {
-        return errorResponse(Status.BAD_REQUEST, "invalid_redirect_uri", errorMessage)
+        return errorResponse(Status.BAD_REQUEST, INVALID_REDIRECT_URI_ERROR_CODE, errorMessage)
     }
 
     def errorResponse(httpCode, errorMessage) {
         return errorResponse(httpCode, null, errorMessage)
     }
 
-    def errorResponse(httpCode, errorCode, errorMessage) {
+    Response errorResponse(httpCode, errorCode, errorMessage) {
         def errorMsgJson = new LinkedHashMap()
         if (errorCode) {
             errorMsgJson["error"] = errorCode

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
@@ -38,7 +38,7 @@ public interface TrustedDirectory {
      * @return a String containing the jwks_uri against which software statement issued by this trusted directory
      * can be validated
      */
-    String getJwksUri();
+    String getDirectoryJwksUri();
 
     /**
      *

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
@@ -54,7 +54,7 @@ public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
     }
 
     @Override
-    public String getJwksUri() {
+    public String getDirectoryJwksUri() {
         return jwksUri;
     }
 

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
@@ -47,7 +47,7 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
      * The name of the claim in the Open Banking Test Directory issued software statement that holds a uid for the
      * software statement
      */
-    final static String softwareStatementSoftwareIdClaimName = "software_client_id";
+    final static String softwareStatementSoftwareIdClaimName = "software_id";
 
     /**
      * Constructor

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
@@ -64,7 +64,7 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
     }
 
     @Override
-    public String getJwksUri() {
+    public String getDirectoryJwksUri() {
         return this.secureApiGatewayJwksUri;
     }
 

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTestTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTestTest.java
@@ -26,7 +26,7 @@ class TrustedDirectoryOpenBankingTestTest {
     @Test
     void testGetters(){
         assertThat(trustedDirectory.getIssuer()).isEqualTo(TrustedDirectoryOpenBankingTest.issuer);
-        assertThat(trustedDirectory.getJwksUri()).isEqualTo(TrustedDirectoryOpenBankingTest.jwksUri);
+        assertThat(trustedDirectory.getDirectoryJwksUri()).isEqualTo(TrustedDirectoryOpenBankingTest.jwksUri);
         assertThat(trustedDirectory.softwareStatementHoldsJwksUri()).isTrue();
         assertThat(trustedDirectory.getSoftwareStatementJwksClaimName()).isNull();
         assertThat(trustedDirectory.getSoftwareStatementJwksUriClaimName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareJwksUriClaimName);

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGatewayTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGatewayTest.java
@@ -30,7 +30,7 @@ class TrustedDirectorySecureApiGatewayTest {
         // When
         // Then
         assertThat(trustedDirectory.getIssuer()).isEqualTo(TrustedDirectorySecureApiGateway.issuer);
-        assertThat(trustedDirectory.getJwksUri()).isEqualTo(testDirectoryFQDN);
+        assertThat(trustedDirectory.getDirectoryJwksUri()).isEqualTo(testDirectoryFQDN);
         assertThat(trustedDirectory.softwareStatementHoldsJwksUri()).isFalse();
         assertThat(trustedDirectory.getSoftwareStatementJwksUriClaimName()).isNull();
         assertThat(trustedDirectory.getSoftwareStatementJwksClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementJwksClaimName);

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStaticTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStaticTest.java
@@ -44,7 +44,7 @@ class TrustedDirectoryServiceStaticTest {
         // Then
         assertThat(directoryConfig).isNotNull();
         assertThat(directoryConfig.getIssuer()).isEqualTo(TrustedDirectorySecureApiGateway.issuer);
-        assertThat(directoryConfig.getJwksUri()).isEqualTo(testDirectoryFQDN);
+        assertThat(directoryConfig.getDirectoryJwksUri()).isEqualTo(testDirectoryFQDN);
         assertThat(directoryConfig.softwareStatementHoldsJwksUri()).isEqualTo(false);
         assertThat(directoryConfig.getSoftwareStatementJwksUriClaimName()).isNull();
         assertThat(directoryConfig.getSoftwareStatementJwksClaimName()).isEqualTo(TrustedDirectorySecureApiGateway.softwareStatementJwksClaimName);


### PR DESCRIPTION
Based on the description of how Dynamic Client Registration should work [here](https://github.com/SecureApiGateway/SecureApiGateway/wiki/About-Dynamic-Client-Registration) we need to ensure that ProcessRegistration.groovy:

    Does not depend upon details within the certificate. This is brittle - we should not require the presented cert to be in eIDAS form.
    Relies upon using the TrustedDirectoriesService to determine the directory from which a software_statement was issued and use the trusted directory JWKS or jwks_uri to validate the certificate rather than trying to inspect the certificate.
    Performs the necessary checks defined in the OB Dynamic Client Registration specification


Issue: https://github.com/secureapigateway/secureapigateway/issues/733