### PR TITLE
729: Adding FetchApiClientJwksFilter

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -100,9 +100,9 @@
       "capture" : [ "response", "request" ]
     },
     {
-      "name": "FetchApiClientAndTrustedDirectoryDataChain",
+      "name": "FetchApiClientResourcesChain",
       "type": "ChainOfFilters",
-      "comment": "This filter chain will set the apiClient and trustedDirectory attributes in the context based on the client_id of the request",
+      "comment": "This filter chain will set the apiClient, apiClientJwkSet and trustedDirectory attributes in the context based on the client_id of the access_token",
       "config" : {
         "filters": [
           {
@@ -120,6 +120,14 @@
             "type": "FetchTrustedDirectoryFilter",
             "config": {
               "trustedDirectoryService": "TrustedDirectoriesService"
+            }
+          },
+          {
+            "comment": "Add the JWKS for the ApiClient to the context attributes",
+            "name": "FetchApiClientJwksFilter",
+            "type": "FetchApiClientJwksFilter",
+            "config": {
+              "jwkSetService": "OBJwkSetService"
             }
           }
         ]

--- a/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -98,7 +98,7 @@
             }
           }
         },
-        "FetchApiClientAndTrustedDirectoryDataChain",
+        "FetchApiClientResourcesChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
@@ -124,8 +124,7 @@
               "routeArgObjApiClient": "apiClient",
               "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
               "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id",
-              "jwkSetService": "${heap['OBJwkSetService']}"
+              "routeArgClientIdFieldName": "client_id"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -118,13 +118,9 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ProcessDetachedSig.groovy",
-            "clientHandler": "IDMClientHandler",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id"
+              "routeArgTrustedAnchor": "openbanking.org.uk"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -117,7 +117,7 @@
             }
           }
         },
-        "FetchApiClientAndTrustedDirectoryDataChain",
+        "FetchApiClientResourcesChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
@@ -143,8 +143,7 @@
               "routeArgObjApiClient": "apiClient",
               "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
               "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "aud",
-              "jwkSetService": "${heap['OBJwkSetService']}"
+              "routeArgClientIdFieldName": "client_id"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -137,13 +137,9 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ProcessDetachedSig.groovy",
-            "clientHandler": "IDMClientHandler",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id"
+              "routeArgTrustedAnchor": "openbanking.org.uk"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -107,7 +107,7 @@
             }
           }
         },
-        "FetchApiClientAndTrustedDirectoryDataChain",
+        "FetchApiClientResourcesChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
@@ -133,8 +133,7 @@
               "routeArgObjApiClient": "apiClient",
               "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
               "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id",
-              "jwkSetService": "${heap['OBJwkSetService']}"
+              "routeArgClientIdFieldName": "client_id"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -127,13 +127,9 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ProcessDetachedSig.groovy",
-            "clientHandler": "IDMClientHandler",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id"
+              "routeArgTrustedAnchor": "openbanking.org.uk"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -117,7 +117,7 @@
             }
           }
         },
-        "FetchApiClientAndTrustedDirectoryDataChain",
+        "FetchApiClientResourcesChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
@@ -143,8 +143,7 @@
               "routeArgObjApiClient": "apiClient",
               "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
               "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "aud",
-              "jwkSetService": "${heap['OBJwkSetService']}"
+              "routeArgClientIdFieldName": "client_id"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -137,13 +137,9 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ProcessDetachedSig.groovy",
-            "clientHandler": "IDMClientHandler",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id"
+              "routeArgTrustedAnchor": "openbanking.org.uk"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -99,7 +99,7 @@
             }
           }
         },
-        "FetchApiClientAndTrustedDirectoryDataChain",
+        "FetchApiClientResourcesChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
@@ -125,8 +125,7 @@
               "routeArgObjApiClient": "apiClient",
               "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
               "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id",
-              "jwkSetService": "${heap['OBJwkSetService']}"
+              "routeArgClientIdFieldName": "client_id"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -119,13 +119,9 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ProcessDetachedSig.groovy",
-            "clientHandler": "IDMClientHandler",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id"
+              "routeArgTrustedAnchor": "openbanking.org.uk"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -117,7 +117,7 @@
             }
           }
         },
-        "FetchApiClientAndTrustedDirectoryDataChain",
+        "FetchApiClientResourcesChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
@@ -143,8 +143,7 @@
               "routeArgObjApiClient": "apiClient",
               "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
               "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "aud",
-              "jwkSetService": "${heap['OBJwkSetService']}"
+              "routeArgClientIdFieldName": "client_id"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -137,13 +137,9 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ProcessDetachedSig.groovy",
-            "clientHandler": "IDMClientHandler",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id"
+              "routeArgTrustedAnchor": "openbanking.org.uk"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -98,7 +98,7 @@
             }
           }
         },
-        "FetchApiClientAndTrustedDirectoryDataChain",
+        "FetchApiClientResourcesChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
@@ -124,8 +124,7 @@
               "routeArgObjApiClient": "apiClient",
               "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
               "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id",
-              "jwkSetService": "${heap['OBJwkSetService']}"
+              "routeArgClientIdFieldName": "client_id"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -118,13 +118,9 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ProcessDetachedSig.groovy",
-            "clientHandler": "IDMClientHandler",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id"
+              "routeArgTrustedAnchor": "openbanking.org.uk"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -117,7 +117,7 @@
             }
           }
         },
-        "FetchApiClientAndTrustedDirectoryDataChain",
+        "FetchApiClientResourcesChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
@@ -143,8 +143,7 @@
               "routeArgObjApiClient": "apiClient",
               "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
               "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "aud",
-              "jwkSetService": "${heap['OBJwkSetService']}"
+              "routeArgClientIdFieldName": "client_id"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -137,13 +137,9 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ProcessDetachedSig.groovy",
-            "clientHandler": "IDMClientHandler",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id"
+              "routeArgTrustedAnchor": "openbanking.org.uk"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -98,7 +98,7 @@
             }
           }
         },
-        "FetchApiClientAndTrustedDirectoryDataChain",
+        "FetchApiClientResourcesChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
@@ -124,8 +124,7 @@
               "routeArgObjApiClient": "apiClient",
               "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
               "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id",
-              "jwkSetService": "${heap['OBJwkSetService']}"
+              "routeArgClientIdFieldName": "client_id"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -118,13 +118,9 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ProcessDetachedSig.groovy",
-            "clientHandler": "IDMClientHandler",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id"
+              "routeArgTrustedAnchor": "openbanking.org.uk"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -117,7 +117,7 @@
             }
           }
         },
-        "FetchApiClientAndTrustedDirectoryDataChain",
+        "FetchApiClientResourcesChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
@@ -143,8 +143,7 @@
               "routeArgObjApiClient": "apiClient",
               "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
               "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "aud",
-              "jwkSetService": "${heap['OBJwkSetService']}"
+              "routeArgClientIdFieldName": "client_id"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -137,13 +137,9 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ProcessDetachedSig.groovy",
-            "clientHandler": "IDMClientHandler",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id"
+              "routeArgTrustedAnchor": "openbanking.org.uk"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -98,7 +98,7 @@
             }
           }
         },
-        "FetchApiClientAndTrustedDirectoryDataChain",
+        "FetchApiClientResourcesChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
@@ -124,8 +124,7 @@
               "routeArgObjApiClient": "apiClient",
               "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
               "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id",
-              "jwkSetService": "${heap['OBJwkSetService']}"
+              "routeArgClientIdFieldName": "client_id"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -118,13 +118,9 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ProcessDetachedSig.groovy",
-            "clientHandler": "IDMClientHandler",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id"
+              "routeArgTrustedAnchor": "openbanking.org.uk"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -117,7 +117,7 @@
             }
           }
         },
-        "FetchApiClientAndTrustedDirectoryDataChain",
+        "FetchApiClientResourcesChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
@@ -143,8 +143,7 @@
               "routeArgObjApiClient": "apiClient",
               "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
               "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "aud",
-              "jwkSetService": "${heap['OBJwkSetService']}"
+              "routeArgClientIdFieldName": "client_id"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -137,13 +137,9 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ProcessDetachedSig.groovy",
-            "clientHandler": "IDMClientHandler",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id"
+              "routeArgTrustedAnchor": "openbanking.org.uk"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -98,7 +98,7 @@
             }
           }
         },
-        "FetchApiClientAndTrustedDirectoryDataChain",
+        "FetchApiClientResourcesChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
@@ -124,8 +124,7 @@
               "routeArgObjApiClient": "apiClient",
               "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
               "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id",
-              "jwkSetService": "${heap['OBJwkSetService']}"
+              "routeArgClientIdFieldName": "client_id"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -118,13 +118,9 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ProcessDetachedSig.groovy",
-            "clientHandler": "IDMClientHandler",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id"
+              "routeArgTrustedAnchor": "openbanking.org.uk"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
@@ -117,13 +117,9 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ProcessDetachedSig.groovy",
-            "clientHandler": "IDMClientHandler",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id"
+              "routeArgTrustedAnchor": "openbanking.org.uk"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
@@ -97,7 +97,7 @@
             }
           }
         },
-        "FetchApiClientAndTrustedDirectoryDataChain",
+        "FetchApiClientResourcesChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
@@ -123,8 +123,7 @@
               "routeArgObjApiClient": "apiClient",
               "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
               "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id",
-              "jwkSetService": "${heap['OBJwkSetService']}"
+              "routeArgClientIdFieldName": "client_id"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -117,7 +117,7 @@
             }
           }
         },
-        "FetchApiClientAndTrustedDirectoryDataChain",
+        "FetchApiClientResourcesChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
@@ -143,8 +143,7 @@
               "routeArgObjApiClient": "apiClient",
               "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
               "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "aud",
-              "jwkSetService": "${heap['OBJwkSetService']}"
+              "routeArgClientIdFieldName": "client_id"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -137,13 +137,9 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ProcessDetachedSig.groovy",
-            "clientHandler": "IDMClientHandler",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id"
+              "routeArgTrustedAnchor": "openbanking.org.uk"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -98,7 +98,7 @@
             }
           }
         },
-        "FetchApiClientAndTrustedDirectoryDataChain",
+        "FetchApiClientResourcesChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
@@ -124,8 +124,7 @@
               "routeArgObjApiClient": "apiClient",
               "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
               "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id",
-              "jwkSetService": "${heap['OBJwkSetService']}"
+              "routeArgClientIdFieldName": "client_id"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -118,13 +118,9 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ProcessDetachedSig.groovy",
-            "clientHandler": "IDMClientHandler",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id"
+              "routeArgTrustedAnchor": "openbanking.org.uk"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -117,7 +117,7 @@
             }
           }
         },
-        "FetchApiClientAndTrustedDirectoryDataChain",
+        "FetchApiClientResourcesChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",
@@ -143,8 +143,7 @@
               "routeArgObjApiClient": "apiClient",
               "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
               "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "aud",
-              "jwkSetService": "${heap['OBJwkSetService']}"
+              "routeArgClientIdFieldName": "client_id"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -137,13 +137,9 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ProcessDetachedSig.groovy",
-            "clientHandler": "IDMClientHandler",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgTrustedAnchor": "openbanking.org.uk",
-              "routeArgClientIdFieldName": "client_id"
+              "routeArgTrustedAnchor": "openbanking.org.uk"
             }
           }
         },

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
@@ -22,6 +22,7 @@ import org.forgerock.openig.alias.ClassAliasResolver;
 
 import com.forgerock.sapi.gateway.dcr.FetchApiClientFilter;
 import com.forgerock.sapi.gateway.fapi.v1.FAPIAdvancedDCRValidationFilter;
+import com.forgerock.sapi.gateway.jwks.FetchApiClientJwksFilter;
 import com.forgerock.sapi.gateway.jwks.RestJwkSetService;
 import com.forgerock.sapi.gateway.jwks.cache.caffeine.CaffeineCachingJwkSetService;
 import com.forgerock.sapi.gateway.jws.RsaJwtSignatureValidator;
@@ -39,6 +40,7 @@ public class SecureApiGatewayClassAliasResolver implements ClassAliasResolver {
         ALIASES.put("TrustedDirectoriesService", TrustedDirectoryService.class);
         ALIASES.put("FetchApiClientFilter", FetchApiClientFilter.class);
         ALIASES.put("FetchTrustedDirectoryFilter", FetchTrustedDirectoryFilter.class);
+        ALIASES.put("FetchApiClientJwksFilter", FetchApiClientJwksFilter.class);
     }
 
     /**

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/jwks/FetchApiClientJwksFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/jwks/FetchApiClientJwksFilter.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.jwks;
+
+import static org.forgerock.openig.util.JsonValues.requiredHeapObject;
+
+import java.net.MalformedURLException;
+
+import org.forgerock.http.Filter;
+import org.forgerock.http.Handler;
+import org.forgerock.http.protocol.Request;
+import org.forgerock.http.protocol.Response;
+import org.forgerock.http.protocol.Status;
+import org.forgerock.json.JsonException;
+import org.forgerock.json.JsonValue;
+import org.forgerock.json.jose.exceptions.FailedToLoadJWKException;
+import org.forgerock.json.jose.jwk.JWKSet;
+import org.forgerock.openig.heap.GenericHeaplet;
+import org.forgerock.openig.heap.HeapException;
+import org.forgerock.services.context.AttributesContext;
+import org.forgerock.services.context.Context;
+import org.forgerock.util.Reject;
+import org.forgerock.util.promise.NeverThrowsException;
+import org.forgerock.util.promise.Promise;
+import org.forgerock.util.promise.Promises;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.forgerock.sapi.gateway.dcr.ApiClient;
+import com.forgerock.sapi.gateway.dcr.FetchApiClientFilter;
+import com.forgerock.sapi.gateway.fapi.FAPIUtils;
+import com.forgerock.sapi.gateway.trusteddirectories.FetchTrustedDirectoryFilter;
+import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectory;
+
+/**
+ * Filter which fetches a {@link JWKSet} containing the keys for an {@link ApiClient} that are registered with a
+ * {@link TrustedDirectory}
+ *
+ * The ApiClient is looked up from the AttributesContext.
+ *
+ * To determine where to find the JWKSet for an ApiClient, the {@link TrustedDirectory} configuration is required.
+ * This is also retrieved from the AttributesContext.
+ *
+ * Therefore, this filter must be installed after a filters which set these attributes, typically: {@link FetchApiClientFilter}
+ * and {@link FetchTrustedDirectoryFilter}
+ */
+public class FetchApiClientJwksFilter implements Filter {
+
+    /**
+     * The key to use to get the JWKSet for the ApiClient from the AttributesContext
+     */
+    public static final String API_CLIENT_JWKS_ATTR_KEY = "apiClientJwkSet";
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    /**
+     * The service to delegate to when looking up remote JWKSets by URL
+     */
+    private final JwkSetService jwkSetService;
+
+    /**
+     * Utility method to retrieve a {@link JWKSet} object from a Context, which belongs to the ApiClient.
+     * This method can be used by other filters to retrieve the JWKSet installed into the attributes context by
+     * this filter.
+     *
+     * @param context the context to retrieve the JWKSet from
+     * @return the JWKSet or null if it is not set in the context.
+     */
+    public static JWKSet getApiClientJwkSetFromContext(Context context) {
+        return (JWKSet) context.asContext(AttributesContext.class).getAttributes().get(API_CLIENT_JWKS_ATTR_KEY);
+    }
+
+    public FetchApiClientJwksFilter(JwkSetService jwkSetService) {
+        Reject.ifNull(jwkSetService, "jwkSetService must be provided");
+        this.jwkSetService = jwkSetService;
+    }
+
+    @Override
+    public Promise<Response, NeverThrowsException> filter(Context context, Request request, Handler next) {
+        final ApiClient apiClient = getApiClient(context);
+        final TrustedDirectory trustedDirectory = getTrustedDirectory(context);
+
+        return getJwkSet(apiClient, trustedDirectory).thenAsync(jwkSet -> {
+            logger.debug("({}) added jwks to context for apiClient", FAPIUtils.getFapiInteractionIdForDisplay(context));
+            context.asContext(AttributesContext.class).getAttributes().put(API_CLIENT_JWKS_ATTR_KEY, jwkSet);
+            return next.handle(context, request);
+        }, ex -> {
+            logger.error("(" + FAPIUtils.getFapiInteractionIdForDisplay(context) + ") failed to load JWKS for apiClient: "
+                    + apiClient + " and trusted directory: " + trustedDirectory + " due to exception", ex);
+            return Promises.newResultPromise(new Response(Status.INTERNAL_SERVER_ERROR));
+        }, rte -> {
+            logger.error("(" + FAPIUtils.getFapiInteractionIdForDisplay(context) + ") failed to load JWKS for apiClient: "
+                    + apiClient + " and trusted directory: " + trustedDirectory + " due to exception", rte);
+            return Promises.newResultPromise(new Response(Status.INTERNAL_SERVER_ERROR));
+        });
+    }
+
+    private TrustedDirectory getTrustedDirectory(Context context) {
+        final TrustedDirectory trustedDirectory = FetchTrustedDirectoryFilter.getTrustedDirectoryFromContext(context);
+        if (trustedDirectory == null) {
+            logger.error("({}) trustedDirectory not found in request context", FAPIUtils.getFapiInteractionIdForDisplay(context));
+            throw new IllegalStateException("trustedDirectory not found in request context");
+        }
+        return trustedDirectory;
+    }
+
+    private ApiClient getApiClient(Context context) {
+        final ApiClient apiClient = FetchApiClientFilter.getApiClientFromContext(context);
+        if (apiClient == null) {
+            logger.error("({}) apiClient not found in request context", FAPIUtils.getFapiInteractionIdForDisplay(context));
+            throw new IllegalStateException("apiClient not found in request context");
+        }
+        return apiClient;
+    }
+
+    /**
+     * The JWKSet for an ApiClient can either be looked up via a URL or it is embedded into the software statement,
+     * use the TrustedDirectory configuration to determine the location of the JWKSet.
+     */
+    private Promise<JWKSet, FailedToLoadJWKException> getJwkSet(ApiClient apiClient, TrustedDirectory trustedDirectory) {
+        if (trustedDirectory.softwareStatementHoldsJwksUri()) {
+            return getJwkSetUsingJwksUri(apiClient);
+        } else {
+            return getJwkSetFromSsaClaim(apiClient, trustedDirectory);
+        }
+    }
+
+    /**
+     * Use the jwkSetService to fetch the JWKSet using the ApiClient.jwksUri
+     */
+    private Promise<JWKSet, FailedToLoadJWKException> getJwkSetUsingJwksUri(ApiClient apiClient) {
+        try {
+            if (apiClient.getJwksUri() == null) {
+                return Promises.newExceptionPromise(new FailedToLoadJWKException("TrustedDirectory configuration " +
+                        "requires the jwksUri to be set for the apiClient"));
+            }
+            return jwkSetService.getJwkSet(apiClient.getJwksUri().toURL());
+        } catch (MalformedURLException e) {
+            return Promises.newExceptionPromise(new FailedToLoadJWKException("Malformed jwksUri", e));
+        }
+    }
+
+    /**
+     * Extract the JWKSet from a claim within the software statement assertion.
+     */
+    private Promise<JWKSet, FailedToLoadJWKException> getJwkSetFromSsaClaim(ApiClient apiClient, TrustedDirectory trustedDirectory) {
+        final String jwksClaimsName = trustedDirectory.getSoftwareStatementJwksClaimName();
+        if (jwksClaimsName == null) {
+            return Promises.newExceptionPromise(new FailedToLoadJWKException("Trusted Directory has " +
+                    "softwareStatemdntHoldsJwksUri=false but is missing softwareStatementJwksClaimName value"));
+        }
+        final JsonValue rawJwks = apiClient.getSoftwareStatementAssertion().getClaimsSet().get(jwksClaimsName);
+        if (rawJwks.isNull()) {
+            return Promises.newExceptionPromise(new FailedToLoadJWKException("SSA is missing claim: " + jwksClaimsName
+                    + " which is expected to contain the JWKS"));
+        }
+        try {
+            return Promises.newResultPromise(JWKSet.parse(rawJwks));
+        } catch (JsonException je) {
+            return Promises.newExceptionPromise(new FailedToLoadJWKException("Invalid JWKS json at claim: " + jwksClaimsName, je));
+        }
+    }
+
+    /**
+     * Heaplet responsible for constructing {@link FetchApiClientFilter} objects.
+     *
+     * Configuration:
+     * - jwkSetService the name of the JwkSetService object on the heap to use to fetch remote JWKSets
+     *
+     * Example config:
+     * {
+     *      "comment": "Add the JWKS for the ApiClient to the context attributes",
+     *      "name": "FetchApiClientJwksFilter",
+     *      "type": "FetchApiClientJwksFilter",
+     *      "config": {
+     *          "jwkSetService": "OBJwkSetService"
+     *       }
+     * }
+     */
+    public static class Heaplet extends GenericHeaplet {
+        @Override
+        public Object create() throws HeapException {
+            final JwkSetService jwkSetService = config.get("jwkSetService").as(requiredHeapObject(heap, JwkSetService.class));
+            return new FetchApiClientJwksFilter(jwkSetService);
+        }
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/jwks/JwkSetService.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/jwks/JwkSetService.java
@@ -20,12 +20,31 @@ import java.net.URL;
 import org.forgerock.json.jose.exceptions.FailedToLoadJWKException;
 import org.forgerock.json.jose.jwk.JWK;
 import org.forgerock.json.jose.jwk.JWKSet;
+import org.forgerock.util.Function;
 import org.forgerock.util.promise.Promise;
 
 /**
  * Service which can retrieve JWKSet and JWK objects
  */
 public interface JwkSetService {
+
+    /**
+     * Creates a helper function which locates a JWK in a JWKSet using the keyId (kid)
+     *
+     * @param keyId String the kid value of the JWK to match
+     * @return Function which takes as input a JWKSet and returns the JWK with matching keyId, if no match can be found
+     * then a FailedToLoadJWKException is thrown
+     */
+    static Function<JWKSet, JWK, FailedToLoadJWKException> findJwkByKeyId(String keyId) {
+        return jwkSet -> {
+            final JWK jwk = jwkSet.findJwk(keyId);
+            if (jwk != null) {
+                return jwk;
+            } else {
+                throw new FailedToLoadJWKException("Failed to find keyId: " + keyId + " in JWKSet");
+            }
+        };
+    }
 
     /**
      * Retrieves a JWKSet for the specified url

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/jwks/RestJwkSetService.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/jwks/RestJwkSetService.java
@@ -21,7 +21,6 @@ import org.forgerock.json.jose.exceptions.FailedToLoadJWKException;
 import org.forgerock.json.jose.jwk.JWK;
 import org.forgerock.json.jose.jwk.JWKSet;
 import org.forgerock.json.jose.jwk.JWKSetParser;
-import org.forgerock.util.Function;
 import org.forgerock.util.promise.Promise;
 
 /**
@@ -42,24 +41,7 @@ public class RestJwkSetService implements JwkSetService {
 
     @Override
     public Promise<JWK, FailedToLoadJWKException> getJwk(URL jwkStoreUrl, String keyId) {
-        return getJwkSet(jwkStoreUrl).then(findJwkByKeyId(keyId));
+        return getJwkSet(jwkStoreUrl).then(JwkSetService.findJwkByKeyId(keyId));
     }
 
-    /**
-     * Creates a helper function which locates a JWK in a JWKSet using the keyId (kid)
-     *
-     * @param keyId String the kid value of the JWK to match
-     * @return Function which takes as input a JWKSet and returns the JWK with matching keyId, if no match can be found
-     * then a FailedToLoadJWKException is thrown
-     */
-    public static Function<JWKSet, JWK, FailedToLoadJWKException> findJwkByKeyId(String keyId) {
-        return jwkSet -> {
-            final JWK jwk = jwkSet.findJwk(keyId);
-            if (jwk != null) {
-                return jwk;
-            } else {
-                throw new FailedToLoadJWKException("Failed to find keyId: " + keyId + " in JWKSet");
-            }
-        };
-    }
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/jwks/cache/CachingJwkSetService.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/jwks/cache/CachingJwkSetService.java
@@ -15,8 +15,6 @@
  */
 package com.forgerock.sapi.gateway.jwks.cache;
 
-import static com.forgerock.sapi.gateway.jwks.RestJwkSetService.findJwkByKeyId;
-
 import java.net.URL;
 
 import org.forgerock.json.jose.exceptions.FailedToLoadJWKException;
@@ -87,7 +85,7 @@ public class CachingJwkSetService implements JwkSetService {
                 logger.debug("keyId: {} not found in cached JWKSet for url: {}, invalidating and fetching JWKSet from url again", keyId, jwkStoreUrl);
                 // JWKSet exists but key not in set, new key may have been added to set since it was cached, fetch it again
                 jwkSetCache.invalidate(jwkStoreUrl);
-                return getJwkSet(jwkStoreUrl).then(findJwkByKeyId(keyId));
+                return getJwkSet(jwkStoreUrl).then(JwkSetService.findJwkByKeyId(keyId));
             }
         };
     }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/jwks/FetchApiClientJwksFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/jwks/FetchApiClientJwksFilterTest.java
@@ -1,0 +1,327 @@
+package com.forgerock.sapi.gateway.jwks;
+
+import static org.forgerock.json.JsonValue.field;
+import static org.forgerock.json.JsonValue.json;
+import static org.forgerock.json.JsonValue.object;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.forgerock.http.protocol.Request;
+import org.forgerock.http.protocol.Response;
+import org.forgerock.http.protocol.Status;
+import org.forgerock.json.JsonValue;
+import org.forgerock.json.jose.exceptions.FailedToLoadJWKException;
+import org.forgerock.json.jose.jwk.JWKSet;
+import org.forgerock.json.jose.jws.JwsHeader;
+import org.forgerock.json.jose.jws.SignedJwt;
+import org.forgerock.json.jose.jwt.JwtClaimsSet;
+import org.forgerock.openig.heap.HeapException;
+import org.forgerock.openig.heap.HeapImpl;
+import org.forgerock.openig.heap.Name;
+import org.forgerock.services.context.AttributesContext;
+import org.forgerock.services.context.Context;
+import org.forgerock.services.context.RootContext;
+import org.forgerock.util.promise.NeverThrowsException;
+import org.forgerock.util.promise.Promise;
+import org.forgerock.util.promise.Promises;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.dcr.ApiClient;
+import com.forgerock.sapi.gateway.dcr.FetchApiClientFilter;
+import com.forgerock.sapi.gateway.jwks.FetchApiClientJwksFilter.Heaplet;
+import com.forgerock.sapi.gateway.jwks.cache.BaseCachingJwkSetServiceTest.BaseCachingTestJwkSetService;
+import com.forgerock.sapi.gateway.jwks.cache.BaseCachingJwkSetServiceTest.ReturnsErrorsJwkStore;
+import com.forgerock.sapi.gateway.trusteddirectories.FetchTrustedDirectoryFilter;
+import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectory;
+import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectoryOpenBankingTest;
+import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectorySecureApiGateway;
+import com.forgerock.sapi.gateway.util.TestHandlers.TestSuccessResponseHandler;
+
+class FetchApiClientJwksFilterTest {
+
+    @Test
+    void fetchJwkSetFromJwksUri() throws Exception {
+        final JWKSet jwkSet = createJwkSet();
+        final URL jwksUri = new URL("https://directory.com/jwks/12345");
+        final MockJwkSetService jwkSetService = new MockJwkSetService(jwkSet, jwksUri);
+        final FetchApiClientJwksFilter filter = new FetchApiClientJwksFilter(jwkSetService);
+
+        fetchJwkSetFromJwksUri(jwkSet, jwksUri, filter);
+    }
+
+    private void fetchJwkSetFromJwksUri(JWKSet expectedJwkSet, URL jwksUri, FetchApiClientJwksFilter filter) throws Exception {
+        final ApiClient apiClient = createApiClientWithJwksUri(jwksUri.toURI());
+        // OB Trusted Dir uses the jwksUri
+        final TrustedDirectory trustedDirectory = new TrustedDirectoryOpenBankingTest();
+        invokeFilterAndValidateSuccessResponse(expectedJwkSet, apiClient, trustedDirectory, filter);
+    }
+
+    @Test
+    void fetchJwkSetFromSoftwareStatement() throws Exception {
+        // Never expect the JwkSetService to get called in this case
+        final ReturnsErrorsJwkStore errorsJwkStore = new ReturnsErrorsJwkStore();
+        final FetchApiClientJwksFilter filter = new FetchApiClientJwksFilter(errorsJwkStore);
+        fetchJwkSetFromSoftwareStatement(filter);
+    }
+
+    private void fetchJwkSetFromSoftwareStatement(FetchApiClientJwksFilter filter) throws Exception {
+        final JWKSet jwkSet = createJwkSet();
+        // SAPI-G directory uses the software statement jwks
+        final TrustedDirectory trustedDirectory = new TrustedDirectorySecureApiGateway("https://blah.com");
+        final ApiClient apiClient = createApiClientWithSoftwareStatementJwks(jwkSet, trustedDirectory.getSoftwareStatementJwksClaimName());
+
+        invokeFilterAndValidateSuccessResponse(jwkSet, apiClient, trustedDirectory, filter);
+    }
+
+    @Test
+    void failsIfApiClientNotFound() {
+        final TestSuccessResponseHandler responseHandler = new TestSuccessResponseHandler();
+        final Context context = new AttributesContext(new RootContext());
+
+        final FetchApiClientJwksFilter filter = new FetchApiClientJwksFilter(new ReturnsErrorsJwkStore());
+
+        final IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> filter.filter(context, new Request(), responseHandler));
+        assertEquals("apiClient not found in request context", exception.getMessage());
+    }
+
+    @Test
+    void failsIfTrustedDirectoryNotFound() {
+        final TestSuccessResponseHandler responseHandler = new TestSuccessResponseHandler();
+        final Context context = new AttributesContext(new RootContext());
+        addApiClientToContext(context, new ApiClient());
+
+        final FetchApiClientJwksFilter filter = new FetchApiClientJwksFilter(new ReturnsErrorsJwkStore());
+
+        final IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> filter.filter(context, new Request(), responseHandler));
+        assertEquals("trustedDirectory not found in request context", exception.getMessage());
+    }
+
+    @Test
+    void failsIfJwkSetServiceThrowsException() throws Exception {
+        final URL jwksUri = new URL("https://directory.com/jwks/12345");
+        final ApiClient apiClient = createApiClientWithJwksUri(jwksUri.toURI());
+        final TrustedDirectory trustedDirectory = new TrustedDirectoryOpenBankingTest();
+
+        final TestSuccessResponseHandler responseHandler = new TestSuccessResponseHandler();
+        final Context context = new AttributesContext(new RootContext());
+        addApiClientToContext(context, apiClient);
+        addTrustedDirectoryToContext(context, trustedDirectory);
+
+        // Returns an Exception promise on every call
+        final JwkSetService jwkSetService = new ReturnsErrorsJwkStore();
+        final FetchApiClientJwksFilter filter = new FetchApiClientJwksFilter(jwkSetService);
+
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, new Request(), responseHandler);
+        final Response response = responsePromise.get(1, TimeUnit.SECONDS);
+        assertEquals(Status.INTERNAL_SERVER_ERROR, response.getStatus());
+        assertFalse(responseHandler.hasBeenInteractedWith(), "ResponseHandler must not get invoked");
+    }
+
+    @Test
+    void failsIfJwksUriIsInvalid() throws Exception {
+        final ApiClient apiClient = createApiClientWithJwksUri(new URI("foo://bar"));
+        final TrustedDirectory trustedDirectory = new TrustedDirectoryOpenBankingTest();
+
+        final TestSuccessResponseHandler responseHandler = new TestSuccessResponseHandler();
+        final Context context = new AttributesContext(new RootContext());
+        addApiClientToContext(context, apiClient);
+        addTrustedDirectoryToContext(context, trustedDirectory);
+
+        final JwkSetService jwkSetService = new ReturnsErrorsJwkStore();
+        final FetchApiClientJwksFilter filter = new FetchApiClientJwksFilter(jwkSetService);
+
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, new Request(), responseHandler);
+        final Response response = responsePromise.get(1, TimeUnit.SECONDS);
+        assertEquals(Status.INTERNAL_SERVER_ERROR, response.getStatus());
+        assertFalse(responseHandler.hasBeenInteractedWith(), "ResponseHandler must not get invoked");
+    }
+
+    @Test
+    void failsIfJwksUriIsNull() throws Exception {
+        final ApiClient apiClient = createApiClientWithJwksUri(null);
+        final TrustedDirectory trustedDirectory = new TrustedDirectoryOpenBankingTest();
+
+        final TestSuccessResponseHandler responseHandler = new TestSuccessResponseHandler();
+        final Context context = new AttributesContext(new RootContext());
+        addApiClientToContext(context, apiClient);
+        addTrustedDirectoryToContext(context, trustedDirectory);
+
+        final JwkSetService jwkSetService = new ReturnsErrorsJwkStore();
+        final FetchApiClientJwksFilter filter = new FetchApiClientJwksFilter(jwkSetService);
+
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, new Request(), responseHandler);
+        final Response response = responsePromise.get(1, TimeUnit.SECONDS);
+        assertEquals(Status.INTERNAL_SERVER_ERROR, response.getStatus());
+        assertFalse(responseHandler.hasBeenInteractedWith(), "ResponseHandler must not get invoked");
+    }
+
+    @Test
+    void failsToGetJwksFromSoftwareStatementIfTrustedDirectorySoftwareStatementJwksClaimNameIsMissing() throws Exception {
+        final ReturnsErrorsJwkStore errorsJwkStore = new ReturnsErrorsJwkStore();
+        final FetchApiClientJwksFilter filter = new FetchApiClientJwksFilter(errorsJwkStore);
+        final JWKSet jwkSet = createJwkSet();
+        final TrustedDirectory misconfiguredDirectory = new TrustedDirectorySecureApiGateway("http://blah") {
+            @Override
+            public String getSoftwareStatementJwksClaimName() {
+                return null;
+            }
+        };
+        final ApiClient apiClient = createApiClientWithSoftwareStatementJwks(jwkSet,"jwks");
+        final Context context = new AttributesContext(new RootContext());
+        addApiClientToContext(context, apiClient);
+        addTrustedDirectoryToContext(context, misconfiguredDirectory);
+
+        final TestSuccessResponseHandler responseHandler = new TestSuccessResponseHandler();
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, new Request(), responseHandler);
+        final Response response = responsePromise.get(1, TimeUnit.SECONDS);
+        assertEquals(Status.INTERNAL_SERVER_ERROR, response.getStatus());
+        assertFalse(responseHandler.hasBeenInteractedWith(), "ResponseHandler must not get invoked");
+    }
+
+    @Test
+    void failsToGetJwksFromSoftwareStatementIfClaimIsNull() throws Exception {
+        final ReturnsErrorsJwkStore errorsJwkStore = new ReturnsErrorsJwkStore();
+        final FetchApiClientJwksFilter filter = new FetchApiClientJwksFilter(errorsJwkStore);
+        final JWKSet jwkSet = createJwkSet();
+        final TrustedDirectory misconfiguredDirectory = new TrustedDirectorySecureApiGateway("http://blah");
+        final ApiClient apiClient = createApiClientWithSoftwareStatementJwks(jwkSet,null);
+        final Context context = new AttributesContext(new RootContext());
+        addApiClientToContext(context, apiClient);
+        addTrustedDirectoryToContext(context, misconfiguredDirectory);
+
+        final TestSuccessResponseHandler responseHandler = new TestSuccessResponseHandler();
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, new Request(), responseHandler);
+        final Response response = responsePromise.get(1, TimeUnit.SECONDS);
+        assertEquals(Status.INTERNAL_SERVER_ERROR, response.getStatus());
+        assertFalse(responseHandler.hasBeenInteractedWith(), "ResponseHandler must not get invoked");
+    }
+
+    @Test
+    void failsToGetJwksFromSoftwareStatementIfClaimsIsInvalidJwksJson() throws Exception {
+        final ReturnsErrorsJwkStore errorsJwkStore = new ReturnsErrorsJwkStore();
+        final FetchApiClientJwksFilter filter = new FetchApiClientJwksFilter(errorsJwkStore);
+        final TrustedDirectory misconfiguredDirectory = new TrustedDirectorySecureApiGateway("http://blah");
+        final ApiClient apiClient = new ApiClient();
+        final JwtClaimsSet claimsSet = new JwtClaimsSet();
+        claimsSet.setClaim(misconfiguredDirectory.getSoftwareStatementJwksClaimName(), json(object(field("keys", "should be a list"))));
+        apiClient.setSoftwareStatementAssertion(new SignedJwt(new JwsHeader(), claimsSet, new byte[0], new byte[0]));
+        final Context context = new AttributesContext(new RootContext());
+        addApiClientToContext(context, apiClient);
+        addTrustedDirectoryToContext(context, misconfiguredDirectory);
+
+        final TestSuccessResponseHandler responseHandler = new TestSuccessResponseHandler();
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, new Request(), responseHandler);
+        final Response response = responsePromise.get(1, TimeUnit.SECONDS);
+        assertEquals(Status.INTERNAL_SERVER_ERROR, response.getStatus());
+        assertFalse(responseHandler.hasBeenInteractedWith(), "ResponseHandler must not get invoked");
+    }
+
+    @Nested
+    class HeapletTests {
+
+        @Test
+        void failsToConstructWhenMissingJwksService() {
+            final HeapImpl heap = new HeapImpl(Name.of("heap"));
+            final JsonValue config = json(object());
+            final HeapException heapException = assertThrows(HeapException.class, () -> new Heaplet().create(Name.of("test"), config, heap));
+            assertEquals("/jwkSetService: Expecting a value", heapException.getCause().getMessage());
+        }
+
+        @Test
+        void successfullyCreatesFilter() throws Exception {
+            final JWKSet jwkSet = createJwkSet();
+            final URL jwksUri = new URL("https://directory.com/jwks/12345");
+            final MockJwkSetService jwkSetService = new MockJwkSetService(jwkSet, jwksUri);
+
+            final HeapImpl heap = new HeapImpl(Name.of("heap"));
+            heap.put("JwkSetService", jwkSetService);
+            final JsonValue config = json(object(field("jwkSetService", "JwkSetService")));
+
+            final FetchApiClientJwksFilter filter = (FetchApiClientJwksFilter) new Heaplet().create(Name.of("test"), config, heap);
+            fetchJwkSetFromJwksUri(jwkSet, jwksUri, filter);
+            fetchJwkSetFromSoftwareStatement(filter);
+        }
+    }
+
+    /**
+     * JwkSetService impl which returns a pre-canned JWKSet for an expectedJwkStoreUrl.
+     * Returns an error if getJwkSet is called with a different url, or i getJwk is called.
+     */
+    private static class MockJwkSetService extends BaseCachingTestJwkSetService {
+        private final JWKSet jwkSet;
+        private final URL expectedJwkStoreUrl;
+
+        private MockJwkSetService(JWKSet jwkSet, URL expectedJwkStoreUrl) {
+            this.jwkSet = jwkSet;
+            this.expectedJwkStoreUrl = expectedJwkStoreUrl;
+        }
+
+        @Override
+        public Promise<JWKSet, FailedToLoadJWKException> getJwkSet(URL jwkStoreUrl) {
+            if (jwkStoreUrl.equals(expectedJwkStoreUrl)) {
+                return Promises.newResultPromise(jwkSet);
+            }
+            return Promises.newExceptionPromise(new FailedToLoadJWKException("actual jwkStoreUrl: " + jwkStoreUrl
+                    + ", does not match expected: " + expectedJwkStoreUrl));
+        }
+    }
+
+    private JWKSet createJwkSet() {
+        return new JWKSet(List.of(RestJwkSetServiceTest.createJWK(UUID.randomUUID().toString()),
+                                  RestJwkSetServiceTest.createJWK(UUID.randomUUID().toString())));
+    }
+
+    private ApiClient createApiClientWithJwksUri(URI jwksUri) {
+        final ApiClient apiClient = new ApiClient();
+        apiClient.setJwksUri(jwksUri);
+        return apiClient;
+    }
+
+    private ApiClient createApiClientWithSoftwareStatementJwks(JWKSet jwkSet, String softwareStatementJwksClaimName) {
+        final ApiClient apiClient = new ApiClient();
+        final JwtClaimsSet claimsSet = new JwtClaimsSet();
+        if (softwareStatementJwksClaimName != null) {
+            claimsSet.setClaim(softwareStatementJwksClaimName, jwkSet.toJsonValue());
+        }
+        apiClient.setSoftwareStatementAssertion(new SignedJwt(new JwsHeader(), claimsSet, new byte[0], new byte[0]));
+        return apiClient;
+    }
+
+    private void addApiClientToContext(Context context, ApiClient apiClient) {
+        context.asContext(AttributesContext.class).getAttributes().put(FetchApiClientFilter.API_CLIENT_ATTR_KEY, apiClient);
+    }
+
+    private void addTrustedDirectoryToContext(Context context, TrustedDirectory trustedDirectory) {
+        context.asContext(AttributesContext.class).getAttributes()
+                .put(FetchTrustedDirectoryFilter.TRUSTED_DIRECTORY_ATTR_KEY, trustedDirectory);
+    }
+
+    private void invokeFilterAndValidateSuccessResponse(JWKSet expectedJwkSet, ApiClient apiClient,
+            TrustedDirectory trustedDirectory, FetchApiClientJwksFilter filter) throws Exception {
+        final TestSuccessResponseHandler responseHandler = new TestSuccessResponseHandler();
+        final Context context = new AttributesContext(new RootContext());
+        addApiClientToContext(context, apiClient);
+        addTrustedDirectoryToContext(context, trustedDirectory);
+
+        assertNull(FetchApiClientJwksFilter.getApiClientJwkSetFromContext(context),
+                "there must be no apiClientJwkSet in the context before the filter is called");
+
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, new Request(), responseHandler);
+        final Response response = responsePromise.get(1, TimeUnit.SECONDS);
+        assertEquals(Status.OK, response.getStatus());
+        assertTrue(responseHandler.hasBeenInteractedWith());
+        assertEquals(expectedJwkSet, FetchApiClientJwksFilter.getApiClientJwkSetFromContext(context));
+    }
+}


### PR DESCRIPTION
FetchApiClientJwksFilter uses the ApiClient and TrustedDirectory objects from the context to lookup and set the apiClientJwkSet attribute. This attribute contains the JWKSet object which holds the keys that the ApiClient has registered with the TrustedDirectory.

Updated ProcessDetachedSig filter to use the apiClientJwkSet attribute to find the key to use when validating the signature.

https://github.com/SecureApiGateway/SecureApiGateway/issues/729