### PR TITLE
733: Remove log line which contains reference to an exception which does not exist in this scope.

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -115,7 +115,6 @@ switch (method.toUpperCase()) {
 
         Jwt ssaJwt = JwtUtils.getSignedJwtFromString(SCRIPT_NAME, ssa, "SSA")
         if (!ssaJwt) {
-            logger.warn(SCRIPT_NAME + "failed to decode software_statement JWT", e)
             return errorResponseFactory.invalidSoftwareStatementErrorResponse("software_statement is not a valid JWT")
         }
 


### PR DESCRIPTION
The new util method JwtUtils.getSignedJwtFromString will have handled and logged the exception, no additional logging is required in this if block.

https://github.com/SecureApiGateway/SecureApiGateway/issues/733