### PR TITLE
740: Fixing signing algorithm validation bug in FAPIAdvancedDCRValidationFilter

### DIFF
--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/FAPIAdvancedDCRValidationFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/FAPIAdvancedDCRValidationFilter.java
@@ -139,7 +139,7 @@ public class FAPIAdvancedDCRValidationFilter implements Filter {
     private Set<String> supportedTokenEndpointAuthMethods;
 
     /**
-     * The field's within the registration request object to validate against the {@link #supportedSigningAlgorithms}
+     * The fields within the registration request object to validate against the {@link #supportedSigningAlgorithms}
      *
      * This is configurable, for the default set of fields see {@link #DEFAULT_REG_OBJ_SIGNING_FIELD_NAMES}
      */

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/FAPIAdvancedDCRValidationFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/FAPIAdvancedDCRValidationFilter.java
@@ -284,14 +284,17 @@ public class FAPIAdvancedDCRValidationFilter implements Filter {
         }
     }
 
+    /**
+     * Validate that values for signing fields are a supported signing algorithm.
+     *
+     * Some fields may be optional for certain types of request, therefore if a field in the registrationObjectSigningFieldNames
+     * collection is not found in the registration request then it is skipped rather than throwing an error.
+     * It is the job of the filter that implements the registration logic to reject requests with missing fields.
+     */
     void validateSigningAlgorithmUsed(JsonValue registrationObject) {
         for (String signingFieldName : registrationObjectSigningFieldNames) {
             final String signingAlg = registrationObject.get(signingFieldName).asString();
-            if (signingAlg == null) {
-                throw new ValidationException(ErrorCode.INVALID_CLIENT_METADATA, "request object must contain field: "
-                        + signingFieldName);
-            }
-            if (!supportedSigningAlgorithms.contains(signingAlg)) {
+            if (signingAlg != null && !supportedSigningAlgorithms.contains(signingAlg)) {
                 throw new ValidationException(ErrorCode.INVALID_CLIENT_METADATA, "request object field: " + signingFieldName
                         + ", must be one of: " + supportedSigningAlgorithms);
             }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/FAPIAdvancedDCRValidationFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/FAPIAdvancedDCRValidationFilterTest.java
@@ -264,17 +264,15 @@ class FAPIAdvancedDCRValidationFilterTest {
         }
 
         @Test
-        void signingAlgorithmFieldsMissing() {
-            // All of these fields must be supplied
+        void signingAlgorithmFieldsMissingAreSkipped() {
             final List<String> signingAlgoFields = List.of("token_endpoint_auth_signing_alg", "id_token_signed_response_alg",
-                    "request_object_signing_alg");
+                                                           "request_object_signing_alg");
 
             // Test submitting requests which each omit one of the fields in turn
             for (String fieldToOmit : signingAlgoFields) {
                 final JsonValue registrationRequest = json(object());
                 signingAlgoFields.stream().filter(field -> !field.equals(fieldToOmit)).forEach(field -> registrationRequest.add(field, "PS256"));
-                runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateSigningAlgorithmUsed, registrationRequest,
-                        ErrorCode.INVALID_CLIENT_METADATA, "request object must contain field: " + fieldToOmit);
+                fapiValidationFilter.validateSigningAlgorithmUsed(registrationRequest);
             }
         }
 


### PR DESCRIPTION
The token_endpoint_auth_signing_alg field is optional in the DCR request (depending on the token_endpoint_auth_method). Changing validation logic for signing fields to skip fields if they are not present in the request.

The job of the FAPIAdvancedDCRValidationFilter is to reject requests that are not FAPI compliant, it is not expected to implement the DCR logic. Therefore, checking if fields are set correctly as per the OAuth2 DCR spec is a job for the filter that implements this logic.

https://github.com/SecureApiGateway/SecureApiGateway/issues/740