### PR TITLE
769: Make TrustedDirectory return URL for directoryJwksUri

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SSAVerifier.groovy
@@ -67,7 +67,7 @@ switch(method.toUpperCase()) {
 
         Request jwksRequest = new Request()
         jwksRequest.setMethod('GET')
-        jwksRequest.setUri(ssaJwksUrl)
+        jwksRequest.setUri(ssaJwksUrl.toString())
         return http.send(jwksRequest).thenAsync(jwksResponse -> {
           jwksRequest.close()
           logger.debug(SCRIPT_NAME + "Back from JWKS URI")

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.trusteddirectories;
 
+import java.net.URL;
+
 /**
  * A Trusted Directory is an external 'trust anchor' that the Secure API Gateway should trust to be the issuer
  * of software statements and the certificates associated with those statements. This interface allows access to
@@ -38,7 +40,7 @@ public interface TrustedDirectory {
      * @return a String containing the jwks_uri against which software statement issued by this trusted directory
      * can be validated
      */
-    String getDirectoryJwksUri();
+    URL getDirectoryJwksUri();
 
     /**
      * The software statement has a JWKS associated with it which contains the keys belonging to the particular software

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
@@ -15,6 +15,9 @@
  */
 package com.forgerock.sapi.gateway.trusteddirectories;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
 
     /*
@@ -30,7 +33,7 @@ public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
      * The URL at which the Open Banking Test Directory JWKS are held, containing public certificates that may be used
      * to validate Open Banking Test directory issues Software Statements.
      */
-    final static String jwksUri = "https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks";
+    final static URL jwksUri;
 
     /*
      * The name of the claim in the Open Banking Test Directory issued software statement that holds the jwks_uri
@@ -48,13 +51,21 @@ public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
      */
     final static String softwareStatementSoftwareIdClaimName = "software_id";
 
+    static {
+        try {
+            jwksUri = new URL("https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks");
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
     @Override
     public String getIssuer() {
         return issuer;
     }
 
     @Override
-    public String getDirectoryJwksUri() {
+    public URL getDirectoryJwksUri() {
         return jwksUri;
     }
 

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.trusteddirectories;
 
+import java.net.URL;
+
 /**
  * Holds static configuration information for the Trusted Directory provided by the Secure API Gateway itself. For
  * development and test purposes it is useful to be able to use the Secure API Gateway to issue SSAs and Certificates
@@ -32,7 +34,7 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
      * The URL at which the Open Banking Test Directory JWKS are held, containing public certificates that may be used
      * to validate Open Banking Test directory issues Software Statements.
      */
-    String secureApiGatewayJwksUri = null;
+    URL secureApiGatewayJwksUri = null;
 
     final static boolean softwareStatementHoldsJwksUri = false;
 
@@ -54,7 +56,7 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
      * @param secureApiGatewayJwksUri The jwks_uri against which SSAs issued by the Secure API Gateway can be
      *                                validated
      */
-    public TrustedDirectorySecureApiGateway(String secureApiGatewayJwksUri){
+    public TrustedDirectorySecureApiGateway(URL secureApiGatewayJwksUri){
         this.secureApiGatewayJwksUri = secureApiGatewayJwksUri;
     }
 
@@ -64,7 +66,7 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
     }
 
     @Override
-    public String getDirectoryJwksUri() {
+    public URL getDirectoryJwksUri() {
         return this.secureApiGatewayJwksUri;
     }
 

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceHeaplet.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceHeaplet.java
@@ -17,6 +17,8 @@ package com.forgerock.sapi.gateway.trusteddirectories;
 
 import static org.forgerock.openig.util.JsonValues.javaDuration;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.time.Duration;
 
 import org.forgerock.openig.heap.GenericHeaplet;
@@ -33,10 +35,15 @@ public class TrustedDirectoryServiceHeaplet extends GenericHeaplet {
 
     @Override
     public Object create() throws HeapException {
-        return createTrustedDirectoryService();
+        try {
+            return createTrustedDirectoryService();
+        } catch (MalformedURLException e) {
+            logger.info("Failed to create instance of TrustedDirectoryService: {}", e.getMessage(), e);
+            throw new HeapException(e);
+        }
     }
 
-    private Object createTrustedDirectoryService() {
+    private Object createTrustedDirectoryService() throws MalformedURLException {
         final Boolean enableIGTestTrustedDirectory = config.get("enableIGTestTrustedDirectory")
                 .as(evaluatedWithHeapProperties())
                 .defaultTo(DEFAULT_IG_TEST_DIRECTORY_ENABLED)
@@ -49,6 +56,7 @@ public class TrustedDirectoryServiceHeaplet extends GenericHeaplet {
 
         logger.debug("Creating Trusted Directory Service with enableIGTestTrustedDirectory: {}, secureApiGatewayJwksUri: {}",
                 enableIGTestTrustedDirectory, secureApiGatewayJwksUri);
-        return new TrustedDirectoryServiceStatic(enableIGTestTrustedDirectory, secureApiGatewayJwksUri);
+        URL secureApiGatewayJwksUrl = new URL(secureApiGatewayJwksUri);
+        return new TrustedDirectoryServiceStatic(enableIGTestTrustedDirectory, secureApiGatewayJwksUrl);
     }
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStatic.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStatic.java
@@ -15,6 +15,7 @@
  */
 package com.forgerock.sapi.gateway.trusteddirectories;
 
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -39,7 +40,7 @@ public class TrustedDirectoryServiceStatic implements TrustedDirectoryService {
      * @param secureApiGatewayJwksUri The jwks_uri against which the signature of SSAs issued by the Trusted Directory
      *                                may be validated
      */
-    public TrustedDirectoryServiceStatic(Boolean enableIGTestTrustedDirectory, String secureApiGatewayJwksUri) {
+    public TrustedDirectoryServiceStatic(Boolean enableIGTestTrustedDirectory, URL secureApiGatewayJwksUri) {
         directoryConfigurations = new HashMap<>();
 
         addOpenBankingTestTrustedDirectory();
@@ -60,7 +61,7 @@ public class TrustedDirectoryServiceStatic implements TrustedDirectoryService {
         return directoryConfigurations.get(issuer);
     }
 
-    private void addGatewayTestTrustedDirectory(String testDirectoryFQDN) {
+    private void addGatewayTestTrustedDirectory(URL testDirectoryFQDN) {
         TrustedDirectory secureApiGatewayTrustedDirectory = new TrustedDirectorySecureApiGateway(testDirectoryFQDN);
         directoryConfigurations.put(secureApiGatewayTrustedDirectory.getIssuer(), secureApiGatewayTrustedDirectory);
     }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/jwks/FetchApiClientJwksFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/jwks/FetchApiClientJwksFilterTest.java
@@ -92,7 +92,8 @@ class FetchApiClientJwksFilterTest {
     private void fetchJwkSetFromSoftwareStatement(FetchApiClientJwksFilter filter) throws Exception {
         final JWKSet jwkSet = createJwkSet();
         // SAPI-G directory uses the software statement jwks
-        final TrustedDirectory trustedDirectory = new TrustedDirectorySecureApiGateway("https://blah.com");
+        final URL secureApiGatewayJwksURI = new URL("https://blah.com");
+        final TrustedDirectory trustedDirectory = new TrustedDirectorySecureApiGateway(secureApiGatewayJwksURI);
         final ApiClient apiClient = createApiClientWithSoftwareStatementJwks(jwkSet, trustedDirectory.getSoftwareStatementJwksClaimName());
 
         invokeFilterAndValidateSuccessResponse(jwkSet, apiClient, trustedDirectory, filter);
@@ -187,7 +188,8 @@ class FetchApiClientJwksFilterTest {
         final ReturnsErrorsJwkStore errorsJwkStore = new ReturnsErrorsJwkStore();
         final FetchApiClientJwksFilter filter = new FetchApiClientJwksFilter(errorsJwkStore);
         final JWKSet jwkSet = createJwkSet();
-        final TrustedDirectory misconfiguredDirectory = new TrustedDirectorySecureApiGateway("http://blah") {
+        final URL secureApiGatewayJwksURI = new URL("https://blah.com");
+        final TrustedDirectory misconfiguredDirectory = new TrustedDirectorySecureApiGateway(secureApiGatewayJwksURI) {
             @Override
             public String getSoftwareStatementJwksClaimName() {
                 return null;
@@ -210,7 +212,8 @@ class FetchApiClientJwksFilterTest {
         final ReturnsErrorsJwkStore errorsJwkStore = new ReturnsErrorsJwkStore();
         final FetchApiClientJwksFilter filter = new FetchApiClientJwksFilter(errorsJwkStore);
         final JWKSet jwkSet = createJwkSet();
-        final TrustedDirectory misconfiguredDirectory = new TrustedDirectorySecureApiGateway("http://blah");
+        final URL secureApiGatewayJwksURI = new URL("https://blah.com");
+        final TrustedDirectory misconfiguredDirectory = new TrustedDirectorySecureApiGateway(secureApiGatewayJwksURI);
         final ApiClient apiClient = createApiClientWithSoftwareStatementJwks(jwkSet,null);
         final Context context = new AttributesContext(new RootContext());
         addApiClientToContext(context, apiClient);
@@ -227,7 +230,8 @@ class FetchApiClientJwksFilterTest {
     void failsToGetJwksFromSoftwareStatementIfClaimsIsInvalidJwksJson() throws Exception {
         final ReturnsErrorsJwkStore errorsJwkStore = new ReturnsErrorsJwkStore();
         final FetchApiClientJwksFilter filter = new FetchApiClientJwksFilter(errorsJwkStore);
-        final TrustedDirectory misconfiguredDirectory = new TrustedDirectorySecureApiGateway("http://blah");
+        final URL secureApiGatewayJwksURI = new URL("https://blah.com");
+        final TrustedDirectory misconfiguredDirectory = new TrustedDirectorySecureApiGateway(secureApiGatewayJwksURI);
         final ApiClient apiClient = new ApiClient();
         final JwtClaimsSet claimsSet = new JwtClaimsSet();
         claimsSet.setClaim(misconfiguredDirectory.getSoftwareStatementJwksClaimName(), json(object(field("keys", "should be a list"))));

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/FetchTrustedDirectoryFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/FetchTrustedDirectoryFilterTest.java
@@ -21,6 +21,9 @@ import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.forgerock.http.protocol.Request;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.jose.jws.JwsHeader;
@@ -32,6 +35,7 @@ import org.forgerock.openig.heap.Name;
 import org.forgerock.services.context.AttributesContext;
 import org.forgerock.services.context.Context;
 import org.forgerock.services.context.RootContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +46,14 @@ import com.forgerock.sapi.gateway.util.TestHandlers.TestSuccessResponseHandler;
 
 class FetchTrustedDirectoryFilterTest {
 
-    private final TrustedDirectoryService trustedDirectoryService =  new TrustedDirectoryServiceStatic(true, "https://test-bank.com");
+    private final String secureApiGatewayJwksUri = "https://test-bank.com";
+    private TrustedDirectoryService trustedDirectoryService;
+
+    @BeforeEach
+    void setUp() throws MalformedURLException {
+        URL secureApiGatewayJwksUrl = new URL(secureApiGatewayJwksUri);
+        trustedDirectoryService = new TrustedDirectoryServiceStatic(true, secureApiGatewayJwksUrl);
+    }
 
     private static ApiClient createApiClient(String issuer) {
         final JwtClaimsSet ssaClaims = new JwtClaimsSet();

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGatewayTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGatewayTest.java
@@ -17,12 +17,23 @@ package com.forgerock.sapi.gateway.trusteddirectories;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class TrustedDirectorySecureApiGatewayTest {
 
-    private static final String testDirectoryFQDN = "https://saig.bigbank.com/jwkms/apiclient/jwks";
-    TrustedDirectorySecureApiGateway trustedDirectory = new TrustedDirectorySecureApiGateway(testDirectoryFQDN);
+    private static URL testDirectoryFQDN ;
+
+    private static TrustedDirectorySecureApiGateway trustedDirectory;
+    @BeforeAll
+    static void setUp() throws MalformedURLException {
+        testDirectoryFQDN = new URL("https://saig.bigbank.com/jwkms/apiclient/jwks");
+        trustedDirectory = new TrustedDirectorySecureApiGateway(testDirectoryFQDN);
+    }
 
     @Test
     void checkFieldValues() {

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStaticTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStaticTest.java
@@ -17,15 +17,25 @@ package com.forgerock.sapi.gateway.trusteddirectories;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class TrustedDirectoryServiceStaticTest {
 
+    private static URL testDirectoryFQDN;
+
+    @BeforeAll
+    static void setupAll() throws MalformedURLException {
+        testDirectoryFQDN = new URL("https://sapi.bigbank.com/jwkms/apiclient/jwks");
+    }
+
     @BeforeEach
     void setUp() {
-
     }
 
     @AfterEach
@@ -33,10 +43,9 @@ class TrustedDirectoryServiceStaticTest {
     }
 
     @Test
-    void getTrustedDirectoryConfiguration_IGTestDirectoryEnabled() {
+    void getTrustedDirectoryConfiguration_IGTestDirectoryEnabled() throws MalformedURLException {
         // Given
         Boolean enableIGTestTrustedDirectory = true;
-        String testDirectoryFQDN = "https://sapi.bigbank.com/jwkms/apiclient/jwks";
         TrustedDirectoryService trustedDirectoryService = new TrustedDirectoryServiceStatic(enableIGTestTrustedDirectory, testDirectoryFQDN);
         // When
         TrustedDirectory directoryConfig = trustedDirectoryService.getTrustedDirectoryConfiguration(TrustedDirectorySecureApiGateway.issuer);
@@ -56,7 +65,6 @@ class TrustedDirectoryServiceStaticTest {
     void getTrustedDirectoryConfiguration_IGTestDirectoryNotEnabled() {
         // Given
         Boolean enableIGTestTrustedDirectory = false;
-        String testDirectoryFQDN = "https://ig.bigbank.com/jwkms/apiclient/jwks";
         TrustedDirectoryService trustedDirectoryService = new TrustedDirectoryServiceStatic(enableIGTestTrustedDirectory, testDirectoryFQDN);
         // When
         TrustedDirectory directoryConfig = trustedDirectoryService.getTrustedDirectoryConfiguration(TrustedDirectorySecureApiGateway.issuer);
@@ -69,7 +77,6 @@ class TrustedDirectoryServiceStaticTest {
     void getTrustedDirectoryConfiguration_getOpenBankingTestTrustedDirectory(){
         // Given
         Boolean enableIGTestTrustedDirectory = false;
-        String testDirectoryFQDN = "https://ig.bigbank.com/jwkms/apiclient/jwks";
         TrustedDirectoryService trustedDirectoryService = new TrustedDirectoryServiceStatic(enableIGTestTrustedDirectory, testDirectoryFQDN);
         // When
         TrustedDirectory directoryConfig = trustedDirectoryService.getTrustedDirectoryConfiguration(TrustedDirectoryOpenBankingTest.issuer);


### PR DESCRIPTION
This will ensure configuration errors are caught earlier.

Issue: https://github.com/secureapigateway/secureapigateway/issues/769