### PR TITLE
764: Removing unused environment variables from config

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/71-ob-jwkms-apiclient-issuecert.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/71-ob-jwkms-apiclient-issuecert.json
@@ -18,8 +18,7 @@
         "routeArgKeyAlias": "&{ca.keystore.alias}",
         "routeArgValidityDays": 365,
         "routeArgKeySize": 2048,
-        "routeArgSigningAlg": "SHA256withRSA",
-        "routeArgEncryptionKey": "&{ca.kek}"
+        "routeArgSigningAlg": "SHA256withRSA"
       }
     }
   }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/72-ob-jwkms-apiclient-getssa.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/72-ob-jwkms-apiclient-getssa.json
@@ -11,18 +11,6 @@
         "format": "PLAIN",
         "algorithm": "AES"
       }
-    },
-    {
-      "name": "SystemAndEnvSecretStore-SSA",
-      "type": "SystemAndEnvSecretStore",
-      "config": {
-        "mappings": [
-          {
-            "secretId": "ig.ssa.secret",
-            "format": "SecretKeyPropertyFormat-SSA"
-          }
-        ]
-      }
     }
   ],
   "handler": {


### PR DESCRIPTION
Removing unused arg: routeArgEncryptionKey for script: JwkmsIssueCert.groovy, env var CA_KEK can also be removed from deployment config.

Heap obj: SystemAndEnvSecretStore-SSA is not referenced anywhere, this is the sole reference to the IG_SSA_SECRET env var which can also be removed from deployment config.

https://github.com/SecureApiGateway/SecureApiGateway/issues/764