### PR TITLE
774: All env vars referenced via config are expected to have an IG_ prefix

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -274,14 +274,14 @@
             "name":"KeyStoreSecretStore-ASPSP",
             "type": "KeyStoreSecretStore",
             "config": {
-              "file": "&{ig.instance.dir}&{aspsp.keystore.path}",
+              "file": "&{ig.instance.dir}&{ig.aspsp.keystore.path}",
               "storeType": "PKCS12",
-              "storePassword": "aspsp.keystore.password",
-              "keyEntryPassword": "aspsp.keystore.password",
+              "storePassword": "ig.aspsp.keystore.password",
+              "keyEntryPassword": "ig.aspsp.keystore.password",
               "secretsProvider": "SystemAndEnvSecretStore-IAM",
               "mappings": [{
-                "secretId": "&{aspsp.jwtsigner.alias}",
-                "aliases": [ "&{aspsp.jwtsigner.alias}" ]
+                "secretId": "&{ig.aspsp.jwtsigner.alias}",
+                "aliases": [ "&{ig.aspsp.jwtsigner.alias}" ]
               }]
             }
           }
@@ -428,8 +428,8 @@
       "config": {
         "file": "&{ig.instance.dir}&{test.directory.signing.key.path}",
         "storeType": "PKCS12",
-        "storePassword": "ca.keystore.storepass",
-        "keyEntryPassword": "ca.keystore.storepass",
+        "storePassword": "ig.ca.keystore.storepass",
+        "keyEntryPassword": "ig.ca.keystore.storepass",
         "secretsProvider": "SystemAndEnvSecretStore-IAM",
         "mappings": [{
           "secretId": "jwt.signer",

--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -426,7 +426,7 @@
       "name":"KeyStoreSecretStore-TA",
       "type": "KeyStoreSecretStore",
       "config": {
-        "file": "&{ig.instance.dir}&{test.directory.signing.key.path}",
+        "file": "&{ig.instance.dir}&{ig.test.directory.signing.key.path}",
         "storeType": "PKCS12",
         "storePassword": "ig.ca.keystore.storepass",
         "keyEntryPassword": "ig.ca.keystore.storepass",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -22,8 +22,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -18,8 +18,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -36,8 +36,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -23,8 +23,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -18,8 +18,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -36,8 +36,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -23,8 +23,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -18,8 +18,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -36,8 +36,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
@@ -23,8 +23,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -18,8 +18,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -36,8 +36,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -23,8 +23,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -22,8 +22,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -18,8 +18,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -36,8 +36,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -23,8 +23,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -22,8 +22,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -18,8 +18,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -36,8 +36,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -23,8 +23,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -18,8 +18,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
@@ -17,8 +17,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -36,8 +36,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
@@ -23,8 +23,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -18,8 +18,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
@@ -22,8 +22,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -36,8 +36,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
@@ -23,8 +23,8 @@
             "args": {
               "routeArgHeaderName": "x-jws-signature",
               "routeArgAlgorithm": "PS256",
-              "routeArgSecretId": "&{aspsp.jwtsigner.alias}",
-              "routeArgKid": "&{aspsp.jwtsigner.kid}",
+              "routeArgSecretId": "&{ig.aspsp.jwtsigner.alias}",
+              "routeArgKid": "&{ig.aspsp.jwtsigner.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
               "routeArgTrustedAnchor": "openbanking.org.uk"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/71-ob-jwkms-apiclient-issuecert.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/71-ob-jwkms-apiclient-issuecert.json
@@ -11,11 +11,11 @@
       "type": "application/x-groovy",
       "file": "JwkmsIssueCert.groovy",
       "args": {
-        "routeArgKeystoreFile": "&{ig.instance.dir}&{ca.keystore.path}",
-        "routeArgKeystoreType": "&{ca.keystore.type}",
-        "routeArgKeystorePass": "&{ca.keystore.storepass}",
-        "routeArgKeyPass": "&{ca.keystore.keypass}",
-        "routeArgKeyAlias": "&{ca.keystore.alias}",
+        "routeArgKeystoreFile": "&{ig.instance.dir}&{ig.ca.keystore.path}",
+        "routeArgKeystoreType": "&{ig.ca.keystore.type}",
+        "routeArgKeystorePass": "&{ig.ca.keystore.storepass}",
+        "routeArgKeyPass": "&{ig.ca.keystore.keypass}",
+        "routeArgKeyAlias": "&{ig.ca.keystore.alias}",
         "routeArgValidityDays": 365,
         "routeArgKeySize": 2048,
         "routeArgSigningAlg": "SHA256withRSA"


### PR DESCRIPTION
Note: when env vars are referenced in IG config, they are made lowercase and underscores replaced with dots. So the prefix in config is `ig.`

See related PR: https://github.com/SecureApiGateway/sapig-openbanking-uk-developer-envs/pull/12

https://github.com/SecureApiGateway/SecureApiGateway/issues/764