### PR TITLE
765: Renaming route to make it clear that the JWKS returned belongs to the Test Directory and not the ApiClient

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -452,7 +452,7 @@
       "comment": "Used to obtain meta information about a trusted directory by look up using the 'iss' field value",
       "config": {
         "enableIGTestTrustedDirectory": true,
-        "SecureApiGatewayJwksUri": "https://&{ig.fqdn}/jwkms/apiclient/jwks"
+        "SecureApiGatewayJwksUri": "https://&{ig.fqdn}/jwkms/testdirectory/jwks"
       }
     },
     {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/75-ob-jwkms-test-directory-jwks.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/75-ob-jwkms-test-directory-jwks.json
@@ -1,8 +1,8 @@
 {
-  "commemnt": "JWK set service for test JWT issuer",
-  "name" : "75 - JWK set service for test JWT issuer",
+  "comment": "Hosts the JWK Set for the Test Directory JWT issuer, used when validating signatures of JWTs produced by the Test Directory",
+  "name" : "75 - JWK Set service for Test Directory JWT issuer",
   "auditService": "AuditService-OB-Route",
-  "condition" : "${matches(request.uri.path, '^/jwkms/apiclient/jwks')}",
+  "condition" : "${matches(request.uri.path, '^/jwkms/testdirectory/jwks')}",
   "handler":     {
     "name": "JwkSetHandler-TA",
     "type": "JwkSetHandler",

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGatewayTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGatewayTest.java
@@ -31,7 +31,7 @@ class TrustedDirectorySecureApiGatewayTest {
     private static TrustedDirectorySecureApiGateway trustedDirectory;
     @BeforeAll
     static void setUp() throws MalformedURLException {
-        testDirectoryFQDN = new URL("https://saig.bigbank.com/jwkms/apiclient/jwks");
+        testDirectoryFQDN = new URL("https://saig.bigbank.com/jwkms/testdirectory/jwks");
         trustedDirectory = new TrustedDirectorySecureApiGateway(testDirectoryFQDN);
     }
 

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStaticTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStaticTest.java
@@ -31,7 +31,7 @@ class TrustedDirectoryServiceStaticTest {
 
     @BeforeAll
     static void setupAll() throws MalformedURLException {
-        testDirectoryFQDN = new URL("https://sapi.bigbank.com/jwkms/apiclient/jwks");
+        testDirectoryFQDN = new URL("https://sapi.bigbank.com/jwkms/testdirectory/jwks");
     }
 
     @BeforeEach


### PR DESCRIPTION
Also updating the route's path to replace apiclient with testdirectory for the same reason.

https://github.com/SecureApiGateway/SecureApiGateway/issues/765