### PR TITLE
731: optional debtor account validation

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -125,6 +125,19 @@
           }
         },
         {
+          "comment": "Validate debtor account in RS",
+          "other": "ValidateDebtorAccountInRS",
+          "name": "ValidateDebtorAccountInRS",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ValidateDebtorAccountInRS.groovy",
+            "args": {
+              "routeArgRsBaseURI": "https://&{rs.fqdn}"
+            }
+          }
+        },
+        {
           "comment": "Calculate response elements in RS",
           "name": "CalculateResponseElementsInRS",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -132,6 +132,7 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ValidateDebtorAccountInRS.groovy",
+            "clientHandler": "ForgeRockClientHandler",
             "args": {
               "routeArgRsBaseURI": "https://&{rs.fqdn}"
             }
@@ -144,9 +145,10 @@
           "config": {
             "type": "application/x-groovy",
             "file": "CalculateResponseElementsInRS.groovy",
+            "clientHandler": "ForgeRockClientHandler",
             "args": {
               "routeArgRsBaseURI": "https://&{rs.fqdn}",
-              "routeArgIntentIdQueryParameter": "intent",
+              "routeArgIntentQueryParameter": "intent",
               "routeArgVersionQueryParameter": "version",
               "routeArgIntentType": "PDC_"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -134,6 +134,19 @@
           }
         },
         {
+          "comment": "Validate debtor account in RS",
+          "other": "ValidateDebtorAccountInRS",
+          "name": "ValidateDebtorAccountInRS",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ValidateDebtorAccountInRS.groovy",
+            "args": {
+              "routeArgRsBaseURI": "https://&{rs.fqdn}"
+            }
+          }
+        },
+        {
           "comment": "Calculate response elements in RS",
           "name": "CalculateResponseElementsInRS",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -141,6 +141,7 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ValidateDebtorAccountInRS.groovy",
+            "clientHandler": "ForgeRockClientHandler",
             "args": {
               "routeArgRsBaseURI": "https://&{rs.fqdn}"
             }
@@ -153,9 +154,10 @@
           "config": {
             "type": "application/x-groovy",
             "file": "CalculateResponseElementsInRS.groovy",
+            "clientHandler": "ForgeRockClientHandler",
             "args": {
               "routeArgRsBaseURI": "https://&{rs.fqdn}",
-              "routeArgIntentIdQueryParameter": "intent",
+              "routeArgIntentQueryParameter": "intent",
               "routeArgVersionQueryParameter": "version",
               "routeArgIntentType": "PDSC_"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -126,6 +126,19 @@
           }
         },
         {
+          "comment": "Validate debtor account in RS",
+          "other": "ValidateDebtorAccountInRS",
+          "name": "ValidateDebtorAccountInRS",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ValidateDebtorAccountInRS.groovy",
+            "args": {
+              "routeArgRsBaseURI": "https://&{rs.fqdn}"
+            }
+          }
+        },
+        {
           "comment": "Calculate response elements in RS",
           "name": "CalculateResponseElementsInRS",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -133,6 +133,7 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ValidateDebtorAccountInRS.groovy",
+            "clientHandler": "ForgeRockClientHandler",
             "args": {
               "routeArgRsBaseURI": "https://&{rs.fqdn}"
             }
@@ -145,9 +146,10 @@
           "config": {
             "type": "application/x-groovy",
             "file": "CalculateResponseElementsInRS.groovy",
+            "clientHandler": "ForgeRockClientHandler",
             "args": {
               "routeArgRsBaseURI": "https://&{rs.fqdn}",
-              "routeArgIntentIdQueryParameter": "intent",
+              "routeArgIntentQueryParameter": "intent",
               "routeArgVersionQueryParameter": "version",
               "routeArgIntentType": "PDSOC_"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -125,6 +125,19 @@
           }
         },
         {
+          "comment": "Validate debtor account in RS",
+          "other": "ValidateDebtorAccountInRS",
+          "name": "ValidateDebtorAccountInRS",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ValidateDebtorAccountInRS.groovy",
+            "args": {
+              "routeArgRsBaseURI": "https://&{rs.fqdn}"
+            }
+          }
+        },
+        {
           "comment": "Calculate response elements in RS",
           "name": "CalculateResponseElementsInRS",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -132,6 +132,7 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ValidateDebtorAccountInRS.groovy",
+            "clientHandler": "ForgeRockClientHandler",
             "args": {
               "routeArgRsBaseURI": "https://&{rs.fqdn}"
             }
@@ -144,9 +145,10 @@
           "config": {
             "type": "application/x-groovy",
             "file": "CalculateResponseElementsInRS.groovy",
+            "clientHandler": "ForgeRockClientHandler",
             "args": {
               "routeArgRsBaseURI": "https://&{rs.fqdn}",
-              "routeArgIntentIdQueryParameter": "intent",
+              "routeArgIntentQueryParameter": "intent",
               "routeArgVersionQueryParameter": "version",
               "routeArgIntentType": "PIC_"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -125,6 +125,19 @@
           }
         },
         {
+          "comment": "Validate debtor account in RS",
+          "other": "ValidateDebtorAccountInRS",
+          "name": "ValidateDebtorAccountInRS",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ValidateDebtorAccountInRS.groovy",
+            "args": {
+              "routeArgRsBaseURI": "https://&{rs.fqdn}"
+            }
+          }
+        },
+        {
           "comment": "Calculate response elements in RS",
           "name": "CalculateResponseElementsInRS",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -132,6 +132,7 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ValidateDebtorAccountInRS.groovy",
+            "clientHandler": "ForgeRockClientHandler",
             "args": {
               "routeArgRsBaseURI": "https://&{rs.fqdn}"
             }
@@ -144,9 +145,10 @@
           "config": {
             "type": "application/x-groovy",
             "file": "CalculateResponseElementsInRS.groovy",
+            "clientHandler": "ForgeRockClientHandler",
             "args": {
               "routeArgRsBaseURI": "https://&{rs.fqdn}",
-              "routeArgIntentIdQueryParameter": "intent",
+              "routeArgIntentQueryParameter": "intent",
               "routeArgVersionQueryParameter": "version",
               "routeArgIntentType": "PISC_"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -132,6 +132,7 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ValidateDebtorAccountInRS.groovy",
+            "clientHandler": "ForgeRockClientHandler",
             "args": {
               "routeArgRsBaseURI": "https://&{rs.fqdn}"
             }
@@ -144,9 +145,10 @@
           "config": {
             "type": "application/x-groovy",
             "file": "CalculateResponseElementsInRS.groovy",
+            "clientHandler": "ForgeRockClientHandler",
             "args": {
               "routeArgRsBaseURI": "https://&{rs.fqdn}",
-              "routeArgIntentIdQueryParameter": "intent",
+              "routeArgIntentQueryParameter": "intent",
               "routeArgVersionQueryParameter": "version",
               "routeArgIntentType": "PISOC_"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -125,6 +125,19 @@
           }
         },
         {
+          "comment": "Validate debtor account in RS",
+          "other": "ValidateDebtorAccountInRS",
+          "name": "ValidateDebtorAccountInRS",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ValidateDebtorAccountInRS.groovy",
+            "args": {
+              "routeArgRsBaseURI": "https://&{rs.fqdn}"
+            }
+          }
+        },
+        {
           "comment": "Calculate response elements in RS",
           "name": "CalculateResponseElementsInRS",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -132,6 +132,7 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ValidateDebtorAccountInRS.groovy",
+            "clientHandler": "ForgeRockClientHandler",
             "args": {
               "routeArgRsBaseURI": "https://&{rs.fqdn}"
             }
@@ -144,9 +145,10 @@
           "config": {
             "type": "application/x-groovy",
             "file": "CalculateResponseElementsInRS.groovy",
+            "clientHandler": "ForgeRockClientHandler",
             "args": {
               "routeArgRsBaseURI": "https://&{rs.fqdn}",
-              "routeArgIntentIdQueryParameter": "intent",
+              "routeArgIntentQueryParameter": "intent",
               "routeArgVersionQueryParameter": "version",
               "routeArgIntentType": "PFC_"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -125,6 +125,19 @@
           }
         },
         {
+          "comment": "Validate debtor account in RS",
+          "other": "ValidateDebtorAccountInRS",
+          "name": "ValidateDebtorAccountInRS",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ValidateDebtorAccountInRS.groovy",
+            "args": {
+              "routeArgRsBaseURI": "https://&{rs.fqdn}"
+            }
+          }
+        },
+        {
           "comment": "Calculate response elements in RS",
           "name": "CalculateResponseElementsInRS",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -125,6 +125,19 @@
           }
         },
         {
+          "comment": "Validate debtor account in RS",
+          "other": "ValidateDebtorAccountInRS",
+          "name": "ValidateDebtorAccountInRS",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ValidateDebtorAccountInRS.groovy",
+            "args": {
+              "routeArgRsBaseURI": "https://&{rs.fqdn}"
+            }
+          }
+        },
+        {
           "comment": "Prepare request for IDM",
           "name": "ProcessPaymentConsent",
           "type": "ScriptableFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -132,6 +132,7 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ValidateDebtorAccountInRS.groovy",
+            "clientHandler": "ForgeRockClientHandler",
             "args": {
               "routeArgRsBaseURI": "https://&{rs.fqdn}"
             }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/CalculateResponseElementsInRS.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CalculateResponseElementsInRS.groovy
@@ -1,8 +1,7 @@
 import org.forgerock.http.protocol.*
 import org.forgerock.json.jose.*
 
-def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
-if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id")
 SCRIPT_NAME = "[CalculateResponseElementsInRS] (" + fapiInteractionId + ") - "
 
 logger.debug(SCRIPT_NAME + "Running...")
@@ -17,7 +16,7 @@ switch(method.toUpperCase()) {
 
         // Create the RS Calculate elements API
         def requestURI = routeArgRsBaseURI + "/backoffice/" + version + "/" + currentApi + "/calculate-elements" + "?" +
-                routeArgIntentIdQueryParameter + "=" + routeArgIntentType
+                routeArgIntentQueryParameter + "=" + routeArgIntentType
         logger.debug(SCRIPT_NAME + " The updated raw request uri: " + requestURI)
 
         Request RSRequest = new Request()

--- a/config/7.1.0/securebanking/ig/scripts/groovy/CalculateResponseElementsInRS.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CalculateResponseElementsInRS.groovy
@@ -1,7 +1,6 @@
-import org.forgerock.http.protocol.*
-import org.forgerock.json.jose.*
-
+// Start script processing area
 def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id")
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
 SCRIPT_NAME = "[CalculateResponseElementsInRS] (" + fapiInteractionId + ") - "
 
 logger.debug(SCRIPT_NAME + "Running...")
@@ -23,8 +22,6 @@ switch(method.toUpperCase()) {
         RSRequest.setUri(requestURI)
         RSRequest.setMethod('POST')
         RSRequest.setEntity(request.entity.getJson())
-        if (request.headers.get("x-fapi-financial-id") != null)
-            RSRequest.putHeaders(request.headers.get("x-fapi-financial-id"))
         logger.debug(SCRIPT_NAME + "Entity to be send to RS Calculate endpoint " + request.entity.getJson())
 
         return http.send(RSRequest).thenAsync(RSResponse -> {

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ValidateDebtorAccountInRS.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ValidateDebtorAccountInRS.groovy
@@ -1,0 +1,53 @@
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
+SCRIPT_NAME = "[ValidateDebtorAccountInRS] (" + fapiInteractionId + ") - "
+
+logger.debug(SCRIPT_NAME + "Running...")
+def method = request.method
+
+
+switch(method.toUpperCase()) {
+
+    case "POST":
+        def debtorAccount = request.entity.getJson().Data.Initiation.DebtorAccount
+        if(debtorAccount !=null){
+            def requestURI = routeArgRsBaseURI + "/backoffice/accounts/search/findByAccountIdentifiers" +
+                    "?name=" + debtorAccount.Name + "&identification=" + debtorAccount.Identification +
+                    "&schemeName=" + debtorAccount.SchemeName
+
+            logger.debug(SCRIPT_NAME + " findByAccountIdentifiers raw request uri: " + requestURI)
+            Request RSRequest = new Request()
+            RSRequest.setUri(requestURI)
+            RSRequest.setMethod('GET')
+            if (request.headers.get("x-fapi-financial-id") != null) {
+                RSRequest.putHeaders(request.headers.get("x-fapi-financial-id"))
+            }
+
+            return http.send(RSRequest).thenAsync(RSResponse -> {
+                def RSResponseStatus = RSResponse.getStatus();
+                if (RSResponseStatus != Status.OK) {
+                    message = "Failed to find the debtor account by account identifiers"
+                    logger.error(SCRIPT_NAME + message)
+                    logger.error(SCRIPT_NAME + RSResponse.getEntity().getJson())
+                    def response = new Response(RSResponseStatus)
+                    response.status = RSResponseStatus
+                    response.entity = RSResponse.entity.getJson()
+                    return newResultPromise(response)
+                }
+                if (RSResponse.getEntity().isRawContentEmpty()) {
+                    message = "Invalid debtor account, the debtor account provided in the consent does not exist"
+                    logger.error(SCRIPT_NAME + message)
+                    response = new Response(Status.BAD_REQUEST)
+                    response.headers['Content-Type'] = "application/json"
+                    response.status = Status.BAD_REQUEST
+                    response.entity = "{ \"error\":\"" + message + "\"}"
+                    return newResultPromise(response)
+                }
+                return next.handle(context, request)
+            })
+        }
+    default:
+        logger.debug(SCRIPT_NAME + "Skipped")
+}
+
+next.handle(context, request)

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ValidateDebtorAccountInRS.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ValidateDebtorAccountInRS.groovy
@@ -16,25 +16,25 @@ switch(method.toUpperCase()) {
                     "&schemeName=" + debtorAccount.SchemeName
 
             logger.debug(SCRIPT_NAME + " findByAccountIdentifiers raw request uri: " + requestURI)
-            Request RSRequest = new Request()
-            RSRequest.setUri(requestURI)
-            RSRequest.setMethod('GET')
+            Request rsRequest = new Request()
+            rsRequest.setUri(requestURI)
+            rsRequest.setMethod('GET')
             if (request.headers.get("x-fapi-financial-id") != null) {
-                RSRequest.putHeaders(request.headers.get("x-fapi-financial-id"))
+                rsRequest.putHeaders(request.headers.get("x-fapi-financial-id"))
             }
 
-            return http.send(RSRequest).thenAsync(RSResponse -> {
-                def RSResponseStatus = RSResponse.getStatus();
+            return http.send(rsRequest).thenAsync(rsResponse -> {
+                def RSResponseStatus = rsResponse.getStatus();
                 if (RSResponseStatus != Status.OK) {
                     message = "Failed to find the debtor account by account identifiers"
                     logger.error(SCRIPT_NAME + message)
-                    logger.error(SCRIPT_NAME + RSResponse.getEntity().getJson())
+                    logger.error(SCRIPT_NAME + rsResponse.getEntity().getJson())
                     def response = new Response(RSResponseStatus)
                     response.status = RSResponseStatus
-                    response.entity = RSResponse.entity.getJson()
+                    response.entity = rsResponse.entity.getJson()
                     return newResultPromise(response)
                 }
-                if (RSResponse.getEntity().isRawContentEmpty()) {
+                if (rsResponse.getEntity().isRawContentEmpty()) {
                     message = "Invalid debtor account, the debtor account provided in the consent does not exist"
                     logger.error(SCRIPT_NAME + message)
                     response = new Response(Status.BAD_REQUEST)

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ValidateDebtorAccountInRS.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ValidateDebtorAccountInRS.groovy
@@ -24,13 +24,13 @@ switch(method.toUpperCase()) {
             }
 
             return http.send(rsRequest).thenAsync(rsResponse -> {
-                def RSResponseStatus = rsResponse.getStatus();
-                if (RSResponseStatus != Status.OK) {
+                def rsResponseStatus = rsResponse.getStatus();
+                if (rsResponseStatus != Status.OK) {
                     message = "Failed to find the debtor account by account identifiers"
                     logger.error(SCRIPT_NAME + message)
                     logger.error(SCRIPT_NAME + rsResponse.getEntity().getJson())
-                    def response = new Response(RSResponseStatus)
-                    response.status = RSResponseStatus
+                    def response = new Response(rsResponseStatus)
+                    response.status = rsResponseStatus
                     response.entity = rsResponse.entity.getJson()
                     return newResultPromise(response)
                 }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ValidateDebtorAccountInRS.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ValidateDebtorAccountInRS.groovy
@@ -1,4 +1,6 @@
+// Start script processing area
 def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
 SCRIPT_NAME = "[ValidateDebtorAccountInRS] (" + fapiInteractionId + ") - "
 
 logger.debug(SCRIPT_NAME + "Running...")
@@ -18,9 +20,6 @@ switch(method.toUpperCase()) {
             Request rsRequest = new Request()
             rsRequest.setUri(requestURI)
             rsRequest.setMethod('GET')
-            if (request.headers.get("x-fapi-financial-id") != null) {
-                rsRequest.putHeaders(request.headers.get("x-fapi-financial-id"))
-            }
 
             return http.send(rsRequest).thenAsync(rsResponse -> {
                 def rsResponseStatus = rsResponse.getStatus();

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ValidateDebtorAccountInRS.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ValidateDebtorAccountInRS.groovy
@@ -1,5 +1,4 @@
 def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
-if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
 SCRIPT_NAME = "[ValidateDebtorAccountInRS] (" + fapiInteractionId + ") - "
 
 logger.debug(SCRIPT_NAME + "Running...")


### PR DESCRIPTION
- Added new scriptable filter for payment initiation routes to validate the debtor account when is provided
- Added new groovy script to call RS to retrieve the account by identifiers provided in the debtor account consent 
> The consent will be rejected with an error description when the debtor account does not exist
```json
# response error example
{
    "Code": "400",
    "Id": "5412c3719b1535a0b93d9fef9322b95d",
    "Message": "[Status: 400 Bad Request]",
    "Errors": {
        "ErrorCode": "UK.OBIE.Field.Invalid",
        "Message": "Bad request [Invalid debtor account, the debtor account provided in the consent does not exist]"
    }
}
```
Issue: https://github.com/secureapigateway/secureapigateway/issues/731