### PR TITLE
765: Allow the Test Trusted Directory to be disabled by an env var

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "security": {
-      "allowIgIssuedTestCerts": true
+      "enableTestTrustedDirectory": {"$bool": "&{ig.test.directory.enabled|true}"}
     },
     "oauth2": {
       "tokenEndpointAuthMethodsSupported": ["private_key_jwt", "tls_client_auth"]
@@ -451,7 +451,7 @@
       "type": "TrustedDirectoriesService",
       "comment": "Used to obtain meta information about a trusted directory by look up using the 'iss' field value",
       "config": {
-        "enableIGTestTrustedDirectory": true,
+        "enableIGTestTrustedDirectory": "${security.enableTestTrustedDirectory}",
         "SecureApiGatewayJwksUri": "https://&{ig.fqdn}/jwkms/testdirectory/jwks"
       }
     },

--- a/config/7.1.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/prod/config/config.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "security": {
-      "allowIgIssuedTestCerts": false
+      "enableTestTrustedDirectory": false
     },
     "oauth2": {
       "tokenEndpointAuthMethodsSupported": ["private_key_jwt", "tls_client_auth"]

--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -62,7 +62,7 @@
               ],
               "routeArgProxyBaseUrl": "https://&{ig.fqdn}/jwkms/jwksproxy",
               "jwkSetService": "${heap['OBJwkSetService']}",
-              "allowIgIssuedTestCerts": "${security.allowIgIssuedTestCerts}",
+              "allowIgIssuedTestCerts": "${security.enableTestTrustedDirectory}",
               "jwtSignatureValidator": "${heap['RsaJwtSignatureValidator']}",
               "tokenEndpointAuthMethodsSupported": "${oauth2.tokenEndpointAuthMethodsSupported}",
               "trustedDirectoryService": "${heap['TrustedDirectoriesService']}"


### PR DESCRIPTION
IG_TEST_DIRECTORY_ENABLED env var controls whether the Test Trusted Directory is enabled.

Note: this can be used to disable the use of the directory in DCR (and OB API calls), as well as disabling the config from the TrustedDirectoryService. The jwkms related routes will still exist and be callable, but the certs produced will be unusable.

https://github.com/SecureApiGateway/SecureApiGateway/issues/765