### PR TITLE
765: Cleaning up configuration of the Test Directory Signing Key Store

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -433,7 +433,7 @@
         "secretsProvider": "SystemAndEnvSecretStore-IAM",
         "mappings": [{
           "secretId": "jwt.signer",
-          "aliases": [ "ig.test.directory.signing.keystore.alias" ]
+          "aliases": [ "&{ig.test.directory.signing.keystore.alias}" ]
         }]
       }
     },

--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -423,17 +423,17 @@
       }
     },
     {
-      "name":"KeyStoreSecretStore-TA",
+      "name":"TestDirectorySigningKeyStore",
       "type": "KeyStoreSecretStore",
       "config": {
-        "file": "&{ig.instance.dir}&{ig.test.directory.signing.key.path}",
+        "file": "&{ig.instance.dir}&{ig.test.directory.signing.keystore.path}",
         "storeType": "PKCS12",
-        "storePassword": "ig.test.directory.ca.keystore.storepass",
-        "keyEntryPassword": "ig.test.directory.ca.keystore.storepass",
+        "storePassword": "ig.test.directory.signing.keystore.storepass",
+        "keyEntryPassword": "ig.test.directory.signing.keystore.storepass",
         "secretsProvider": "SystemAndEnvSecretStore-IAM",
         "mappings": [{
           "secretId": "jwt.signer",
-          "aliases": [ "jwt-signer" ]
+          "aliases": [ "ig.test.directory.signing.keystore.alias" ]
         }]
       }
     },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/70-ob-jwkms-rcs-signresponse.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/70-ob-jwkms-rcs-signresponse.json
@@ -49,7 +49,7 @@
           "type": "JwtBuilderFilter",
           "config": {
             "template": "${attributes.processedPayload}",
-            "secretsProvider": "KeyStoreSecretStore-TA",
+            "secretsProvider": "TestDirectorySigningKeyStore",
             "signature": {
               "secretId": "jwt.signer",
               "algorithm": "PS256"

--- a/config/7.1.0/securebanking/ig/routes/routes-service/72-ob-jwkms-apiclient-getssa.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/72-ob-jwkms-apiclient-getssa.json
@@ -49,7 +49,7 @@
           "type": "JwtBuilderFilter",
           "config": {
             "template": "${attributes.ssaPayload}",
-            "secretsProvider": "KeyStoreSecretStore-TA",
+            "secretsProvider": "TestDirectorySigningKeyStore",
             "signature": {
               "secretId": "jwt.signer",
               "algorithm": "PS256"

--- a/config/7.1.0/securebanking/ig/routes/routes-service/75-ob-jwkms-test-directory-jwks.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/75-ob-jwkms-test-directory-jwks.json
@@ -7,7 +7,7 @@
     "name": "JwkSetHandler-TA",
     "type": "JwkSetHandler",
     "config": {
-      "secretsProvider": "KeyStoreSecretStore-TA",
+      "secretsProvider": "TestDirectorySigningKeyStore",
       "purposes": [{
         "secretId": "jwt.signer",
         "keyUsage": "SIGN"


### PR DESCRIPTION
The configuration was reusing config for the ca keystore, changed to use its own set of env vars.

Made the alias name configurable.

Renamed the store to TestDirectorySigningKeyStore.

Related PR: https://github.com/SecureApiGateway/sapig-openbanking-uk-developer-envs/pull/15

https://github.com/SecureApiGateway/SecureApiGateway/issues/765