### PR TITLE
783: Removing unused heap objects from jwkms routes

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/70-ob-jwkms-rcs-signresponse.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/70-ob-jwkms-rcs-signresponse.json
@@ -3,28 +3,6 @@
   "name": "70 - OB JWKMS",
   "auditService": "AuditService-OB-Route",
   "condition": "${matches(request.uri.path, '^/jwkms/rcs/signresponse')}",
-  "heap": [
-    {
-      "name": "SecretKeyPropertyFormat-RCS",
-      "type": "SecretKeyPropertyFormat",
-      "config": {
-        "format": "PLAIN",
-        "algorithm": "AES"
-      }
-    },
-    {
-      "name": "SystemAndEnvSecretStore-RCS",
-      "type": "SystemAndEnvSecretStore",
-      "config": {
-        "mappings": [
-          {
-            "secretId": "ig.rcs.secret",
-            "format": "SecretKeyPropertyFormat-RCS"
-          }
-        ]
-      }
-    }
-  ],
   "handler": {
     "type": "Chain",
     "config": {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/72-ob-jwkms-apiclient-getssa.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/72-ob-jwkms-apiclient-getssa.json
@@ -3,16 +3,6 @@
   "name": "72 - API client onboarding - generate test SSA",
   "auditService": "AuditService-OB-Route",
   "condition": "${matches(request.uri.path, '^/jwkms/apiclient/getssa')}",
-  "heap": [
-    {
-      "name": "SecretKeyPropertyFormat-SSA",
-      "type": "SecretKeyPropertyFormat",
-      "config": {
-        "format": "PLAIN",
-        "algorithm": "AES"
-      }
-    }
-  ],
   "handler": {
     "type": "Chain",
     "config": {


### PR DESCRIPTION
Heap object: SystemAndEnvSecretStore-RCS is not referenced. It looks like an old Secret Store that may have been used to implement HMAC JWT signing. The env var IG_RCS_SECRET can now be removed.

Also removing SecretKeyPropertyFormat-RCS and SecretKeyPropertyFormat-SSA objects as they are not referenced anywhere.

https://github.com/SecureApiGateway/SecureApiGateway/issues/783