### PR TITLE
776: Updating Dockerfile to run IG as forgerock user

### DIFF
--- a/docker/7.1.0/ig/Dockerfile
+++ b/docker/7.1.0/ig/Dockerfile
@@ -1,17 +1,19 @@
 FROM gcr.io/forgerock-io/ig:7.1.0
 
-# Copy all config files into the docker image.
-# The default ig directory is /var/ig, and it expects subfolders config/ and scripts/ (if required)
-
-COPY --chown=forgerock:root lib /opt/ig/lib
-
-COPY --chown=forgerock:root audit-schemas /var/ig/audit-schemas/
-COPY --chown=forgerock:root scripts /var/ig/scripts/
-COPY --chown=forgerock:root config /var/ig/config/
-COPY --chown=forgerock:root bin/import-pem-certs.sh /home/forgerock
-# Create dir where secrets can be mounted into
-RUN mkdir /var/ig/secrets
-
+# Base image is using the forgerock user, switch to root for priviledged tasks
 USER root
 RUN sed -i 's/stable\/updates/stable-security\/updates/' /etc/apt/sources.list
 RUN apt-get update && apt-get install nano
+
+# Switching back to forgerock user, app will run as this
+USER forgerock
+# Create dir where secrets can be mounted into
+RUN mkdir /var/ig/secrets
+COPY --chown=forgerock:root bin/import-pem-certs.sh /home/forgerock
+COPY --chown=forgerock:root lib /opt/ig/lib
+
+# Copy all config files into the docker image.
+# The default ig directory is /var/ig, and it expects subfolders config/ and scripts/ (if required)
+COPY --chown=forgerock:root audit-schemas /var/ig/audit-schemas/
+COPY --chown=forgerock:root scripts /var/ig/scripts/
+COPY --chown=forgerock:root config /var/ig/config/


### PR DESCRIPTION
The forgerock user is created by the base image and is intended to be used to run the application.

Switching to root to run some privileged commands only.

Reordering the Dockerfile to place things that change more frequently near the end to make better use of layer caching.

https://github.com/SecureApiGateway/SecureApiGateway/issues/776