### PR TITLE
793: Protecting access to RCS-UI

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -211,28 +211,22 @@
         "handler": "ReverseProxyHandler"
       }
     },
+
     {
-      "name": "SBATReverseProxyHandlerRsNoCapture",
-      "comment": "ReverseProxyHandler for calls to the SBAT RS",
+      "name": "RcsReverseProxyHandler",
+      "comment": "ReverseProxyHandler for calls to the RCS",
       "type": "Chain",
       "config": {
         "filters": [
-          {
-            "comment": "Add x-ob-url header (used by RS)",
-            "name": "HeaderFilter-Add-x-ob-url",
-            "type": "HeaderFilter",
-            "config": {
-              "messageType": "REQUEST",
-              "add": {
-                "x-ob-url": [
-                  "https://&{ig.fqdn}${contexts.router.remainingUri}"
-                ]
-              }
-            }
-          },
           "TransactionIdOutboundFilter"
         ],
-        "handler": "ReverseProxyHandlerNoCapture"
+        "handler": {
+          "name": "RcsReverseProxyHandlerInner",
+          "type": "ReverseProxyHandler",
+          "config": {
+            "vertx": "${vertxConfig}"
+          }
+        }
       }
     },
     {

--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -212,6 +212,30 @@
       }
     },
     {
+      "name": "SBATReverseProxyHandlerRsNoCapture",
+      "comment": "ReverseProxyHandler for calls to the SBAT RS",
+      "type": "Chain",
+      "config": {
+        "filters": [
+          {
+            "comment": "Add x-ob-url header (used by RS)",
+            "name": "HeaderFilter-Add-x-ob-url",
+            "type": "HeaderFilter",
+            "config": {
+              "messageType": "REQUEST",
+              "add": {
+                "x-ob-url": [
+                  "https://&{ig.fqdn}${contexts.router.remainingUri}"
+                ]
+              }
+            }
+          },
+          "TransactionIdOutboundFilter"
+        ],
+        "handler": "ReverseProxyHandlerNoCapture"
+      }
+    },
+    {
       "name" : "AmService-OBIE",
       "type" : "AmService",
       "config" : {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
@@ -17,7 +17,8 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "origin"
             ],
             "add": {
               "X-Forwarded-Host": [

--- a/config/7.1.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
@@ -18,7 +18,8 @@
             "remove": [
               "host",
               "X-Forwarded-Host",
-              "origin"
+              "origin",
+              "referer"
             ],
             "add": {
               "X-Forwarded-Host": [

--- a/config/7.1.0/securebanking/ig/routes/routes-service/81-rcs-ui.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/81-rcs-ui.json
@@ -3,7 +3,7 @@
   "name": "81 - RCS UI Access",
   "auditService": "AuditService-OB-Route",
   "condition": "${matches(request.uri.path, '^/rcs/consent')}",
-  "baseURI": "http://securebanking-ui-rcs-ui:8080",
+  "baseURI": "http://&{rcs.ui.internal.svc}:8080",
   "capture": [
     "response",
     "request"
@@ -76,7 +76,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "RcsReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/81-rcs-ui.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/81-rcs-ui.json
@@ -21,6 +21,22 @@
           }
         },
         {
+          "name": "ConsentRequestJwtValidationFilter",
+          "type": "IdTokenValidationFilter",
+          "comment": "IdTokenValidationFilter is an extension of JwtValidationFilter which, in addition to signature validation, validates to the following claims: aud, iss, exp, iat",
+          "config": {
+            "idToken": "${request.queryParams.getFirst('consent_request')}",
+            "verificationSecretId": "any.value.in.regex.format",
+            "secretsProvider": "SecretsProvider-AmJWK",
+            "issuer": "https://&{ig.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+            "audience": "&{rcs.consent.response.jwt.issuer}"
+          }
+        },
+        {
+          "name": "ConsentRequestAccessAuthorisationFilter",
+          "type": "ConsentRequestAccessAuthorisationFilter"
+        },
+        {
           "comment": "Adjust URL for downstream resource server",
           "type": "UriPathRewriteFilter",
           "config": {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/81-rcs-ui.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/81-rcs-ui.json
@@ -1,0 +1,66 @@
+{
+  "comment": "PSU access to RCS UI, ensure PSU is authenticated",
+  "name": "81 - RCS UI Access",
+  "auditService": "AuditService-OB-Route",
+  "condition": "${matches(request.uri.path, '^/rcs/consent')}",
+  "baseURI": "http://securebanking-ui-rcs-ui:8080",
+  "capture": [
+    "response",
+    "request"
+  ],
+  "handler": {
+    "type": "Chain",
+    "config": {
+      "filters": [
+        "SBATFapiInteractionFilterChain",
+        {
+          "name": "SingleSignOnFilter",
+          "type": "SingleSignOnFilter",
+          "config": {
+            "amService": "AmService-OBIE"
+          }
+        },
+        {
+          "comment": "Adjust URL for downstream resource server",
+          "type": "UriPathRewriteFilter",
+          "config": {
+            "mappings": {
+              "/rcs/consent": "/consent"
+            },
+            "failureHandler": {
+              "type": "StaticResponseHandler",
+              "config": {
+                "status": 500,
+                "headers": {
+                  "Content-Type": [
+                    "text/plain"
+                  ]
+                },
+                "entity": "Invalid URL produced"
+              }
+            }
+          }
+        },
+        {
+          "comment": "Add host header for downstream resource server",
+          "name": "HeaderFilter-RemoveHeaders",
+          "type": "HeaderFilter",
+          "config": {
+            "messageType": "REQUEST",
+            "remove": [
+              "host",
+              "X-Forwarded-Host",
+              "X-Scheme",
+              "X-Forwarded-Scheme",
+              "X-Forwarded-Proto",
+              "upgrade-insecure-requests",
+              "ssl-client-verify",
+              "referer"
+            ]
+          }
+        }
+      ],
+      "handler": "SBATReverseProxyHandlerRs"
+    }
+  }
+}

--- a/config/7.1.0/securebanking/ig/routes/routes-service/81-rcs-ui.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/81-rcs-ui.json
@@ -2,7 +2,7 @@
   "comment": "PSU access to RCS UI, ensure PSU is authenticated",
   "name": "81 - RCS UI Access",
   "auditService": "AuditService-OB-Route",
-  "condition": "${matches(request.uri.path, '^/rcs/consent')}",
+  "condition": "${matches(request.uri.path, '^/rcs/ui/consent')}",
   "baseURI": "http://&{rcs.ui.internal.svc}:8080",
   "capture": [
     "response",
@@ -41,7 +41,7 @@
           "type": "UriPathRewriteFilter",
           "config": {
             "mappings": {
-              "/rcs/consent": "/consent"
+              "/rcs/ui/consent": "/consent"
             },
             "failureHandler": {
               "type": "StaticResponseHandler",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/82-rcs-ui-assets.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/82-rcs-ui-assets.json
@@ -2,8 +2,8 @@
   "comment": "PSU access to RCS UI, ensure PSU is authenticated - this route matches the UI assets and has capturing turned off",
   "name": "82 - RCS UI Access assets",
   "auditService": "AuditService-OB-Route",
-  "condition": "${matches(request.uri.path, '^/rcs')}",
-  "baseURI": "http://securebanking-ui-rcs-ui:8080",
+  "condition": "${matches(request.uri.path, '^/rcs/')}",
+  "baseURI": "http://&{rcs.ui.internal.svc}:8080",
   "handler": {
     "type": "Chain",
     "config": {
@@ -56,7 +56,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRsNoCapture"
+      "handler": "RcsReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/82-rcs-ui-assets.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/82-rcs-ui-assets.json
@@ -2,7 +2,7 @@
   "comment": "PSU access to RCS UI, ensure PSU is authenticated - this route matches the UI assets and has capturing turned off",
   "name": "82 - RCS UI Access assets",
   "auditService": "AuditService-OB-Route",
-  "condition": "${matches(request.uri.path, '^/rcs/')}",
+  "condition": "${matches(request.uri.path, '^/rcs/ui/')}",
   "baseURI": "http://&{rcs.ui.internal.svc}:8080",
   "handler": {
     "type": "Chain",
@@ -21,7 +21,7 @@
           "type": "UriPathRewriteFilter",
           "config": {
             "mappings": {
-              "/rcs": "/"
+              "/rcs/ui/": "/"
             },
             "failureHandler": {
               "type": "StaticResponseHandler",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/82-rcs-ui-assets.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/82-rcs-ui-assets.json
@@ -1,0 +1,62 @@
+{
+  "comment": "PSU access to RCS UI, ensure PSU is authenticated - this route matches the UI assets and has capturing turned off",
+  "name": "82 - RCS UI Access assets",
+  "auditService": "AuditService-OB-Route",
+  "condition": "${matches(request.uri.path, '^/rcs')}",
+  "baseURI": "http://securebanking-ui-rcs-ui:8080",
+  "handler": {
+    "type": "Chain",
+    "config": {
+      "filters": [
+        "SBATFapiInteractionFilterChain",
+        {
+          "name": "SingleSignOnFilter",
+          "type": "SingleSignOnFilter",
+          "config": {
+            "amService": "AmService-OBIE"
+          }
+        },
+        {
+          "comment": "Adjust URL for downstream resource server",
+          "type": "UriPathRewriteFilter",
+          "config": {
+            "mappings": {
+              "/rcs": "/"
+            },
+            "failureHandler": {
+              "type": "StaticResponseHandler",
+              "config": {
+                "status": 500,
+                "headers": {
+                  "Content-Type": [
+                    "text/plain"
+                  ]
+                },
+                "entity": "Invalid URL produced"
+              }
+            }
+          }
+        },
+        {
+          "comment": "Add host header for downstream resource server",
+          "name": "HeaderFilter-RemoveHeaders",
+          "type": "HeaderFilter",
+          "config": {
+            "messageType": "REQUEST",
+            "remove": [
+              "host",
+              "X-Forwarded-Host",
+              "X-Scheme",
+              "X-Forwarded-Scheme",
+              "X-Forwarded-Proto",
+              "upgrade-insecure-requests",
+              "ssl-client-verify",
+              "referer"
+            ]
+          }
+        }
+      ],
+      "handler": "SBATReverseProxyHandlerRsNoCapture"
+    }
+  }
+}

--- a/secure-api-gateway-ig-extensions/pom.xml
+++ b/secure-api-gateway-ig-extensions/pom.xml
@@ -51,6 +51,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.forgerock.openig</groupId>
+            <artifactId>openig-openam</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
             <version>9.26</version>

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
@@ -20,9 +20,11 @@ import java.util.Map;
 
 import org.forgerock.openig.alias.ClassAliasResolver;
 
+import com.forgerock.sapi.gateway.consent.ConsentRequestAccessAuthorisationFilter;
 import com.forgerock.sapi.gateway.dcr.idm.FetchApiClientFilter;
 import com.forgerock.sapi.gateway.dcr.request.RegistrationRequestEntityValidatorFilter;
 import com.forgerock.sapi.gateway.dcr.sigvalidation.RegistrationRequestJwtSignatureValidationFilter;
+import com.forgerock.sapi.gateway.dcr.FetchApiClientFilter;
 import com.forgerock.sapi.gateway.fapi.v1.FAPIAdvancedDCRValidationFilter;
 import com.forgerock.sapi.gateway.jwks.FetchApiClientJwksFilter;
 import com.forgerock.sapi.gateway.jwks.RestJwkSetService;
@@ -49,6 +51,7 @@ public class SecureApiGatewayClassAliasResolver implements ClassAliasResolver {
         ALIASES.put("DefaultTransportCertValidator", DefaultTransportCertValidator.class);
         ALIASES.put("RegistrationRequestJwtSignatureValidationFilter", RegistrationRequestJwtSignatureValidationFilter.class);
         ALIASES.put("RegistrationRequestEntityValidatorFilter", RegistrationRequestEntityValidatorFilter.class);
+        ALIASES.put("ConsentRequestAccessAuthorisationFilter", ConsentRequestAccessAuthorisationFilter.class);
     }
 
     /**

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/consent/ConsentRequestAccessAuthorisationFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/consent/ConsentRequestAccessAuthorisationFilter.java
@@ -40,19 +40,19 @@ import com.forgerock.sapi.gateway.fapi.FAPIUtils;
  * Filter that protects access to a consent request by validating that an end user browser session belongs to the
  * same user that is specified in the signed consent request JWT (sent from AM). This can be used in filter chains
  * which protect Remote Consent flows.
- *
+ * <p>
  * This filter depends on the {@link SsoTokenContext} and {@link JwtValidationContext}, therefore it must be installed
  * after filters which add these contexts.
- *
+ * <p>
  * The {@link SsoTokenContext} is used to determine the user that is logged in, by inspecting the session "uid".
- *
+ * <p>
  * The {@link JwtValidationContext} is used to determine the user that owns the consent request, by inspecting the
  * "username" claim. It is assumed that consent request JWT has been fully validated, that the signature has been verified and that
  * the "exp", "iat", "iss" and "aud" claims have all been validated.
- *
+ * <p>
  * If the SSO user matches the consent user then this filter passes the request on to the next handler in the chain.
  * Otherwise, this filter responds with HTTP 401.
- *
+ * <p>
  * If any exceptions are raised when extracting the user data from the contexts then this filter responds with HTTP 500.
  * This is because an exception indicates either an error in the IG configuration or AM configuration; there is no action
  * that an end user can take to resolve the issue.
@@ -154,6 +154,17 @@ public class ConsentRequestAccessAuthorisationFilter implements Filter {
 
     /**
      * Heaplet which creates {@link ConsentRequestAccessAuthorisationFilter}
+     * <p>
+     * Optional config:
+     * - consentRequestUserIdClaim: the name of the claim in the consent_request JWT which contains the userId (default: username)
+     * - ssoTokenUserIdKey: {@link SsoTokenContext#getInfo()} key which contains the userId (default: uid)
+     * <p>
+     * Example config:
+     * {
+     *             "name": "ConsentRequestAccessAuthorisationFilter",
+     *             "type": "ConsentRequestAccessAuthorisationFilter",
+     *             "comment": "Verify user SSO session is allowed to access the consent"
+     * }
      */
     public static class Heaplet extends GenericHeaplet {
         @Override

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/consent/ConsentRequestAccessAuthorisationFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/consent/ConsentRequestAccessAuthorisationFilter.java
@@ -145,18 +145,15 @@ public class ConsentRequestAccessAuthorisationFilter implements Filter {
     private String getUserIdFromSsoToken(Context context) {
         final SsoTokenContext ssoContext = context.asContext(SsoTokenContext.class);
         final Map<String, Object> info = ssoContext.getInfo();
-        if (!info.containsKey(ssoTokenUserIdKey)) {
-            throw new IllegalStateException("SsoTokenContext is missing required uid value");
+        final Object userId = info.get(ssoTokenUserIdKey);
+        if (!(userId instanceof String)) {
+            throw new IllegalStateException("SsoTokenContext.uid is missing or not a string");
         }
-        final Object ssoTokenUserIdObj = info.get(ssoTokenUserIdKey);
-        if (!(ssoTokenUserIdObj instanceof String)) {
-            throw new IllegalStateException("SsoTokenContext.uid must be a string");
-        }
-        return (String) ssoTokenUserIdObj;
+        return (String) userId;
     }
 
     /**
-     *
+     * Heaplet which creates {@link ConsentRequestAccessAuthorisationFilter}
      */
     public static class Heaplet extends GenericHeaplet {
         @Override

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/consent/ConsentRequestAccessAuthorisationFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/consent/ConsentRequestAccessAuthorisationFilterTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.consent;
+
+import static org.forgerock.json.JsonValue.field;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.forgerock.json.JsonValue.json;
+import static org.forgerock.json.JsonValue.object;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.forgerock.http.protocol.Request;
+import org.forgerock.http.protocol.Response;
+import org.forgerock.http.protocol.Status;
+import org.forgerock.json.JsonValue;
+import org.forgerock.json.jose.jwt.JwtClaimsSet;
+import org.forgerock.openig.filter.jwt.JwtValidationContext;
+import org.forgerock.openig.heap.HeapImpl;
+import org.forgerock.openig.heap.Name;
+import org.forgerock.openig.openam.SsoTokenContext;
+import org.forgerock.openig.tools.session.SessionInfo;
+import org.forgerock.services.context.Context;
+import org.forgerock.services.context.RootContext;
+import org.forgerock.util.promise.NeverThrowsException;
+import org.forgerock.util.promise.Promise;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.consent.ConsentRequestAccessAuthorisationFilter.ExceptionHandler;
+import com.forgerock.sapi.gateway.consent.ConsentRequestAccessAuthorisationFilter.Heaplet;
+import com.forgerock.sapi.gateway.util.TestHandlers.TestSuccessResponseHandler;
+
+class ConsentRequestAccessAuthorisationFilterTest {
+
+    private static final String TEST_USER_ID = "test-user";
+    private CapturingExceptionHandler exceptionHandler;
+    private ConsentRequestAccessAuthorisationFilter filter;
+
+    @BeforeEach
+    void beforeEach() {
+        exceptionHandler = new CapturingExceptionHandler();
+        filter = new ConsentRequestAccessAuthorisationFilter(
+                ConsentRequestAccessAuthorisationFilter.DEFAULT_CONSENT_REQUEST_USER_ID_CLAIM,
+                ConsentRequestAccessAuthorisationFilter.DEFAULT_SSO_TOKEN_USER_ID_KEY,
+                exceptionHandler);
+    }
+
+
+    /**
+     * Wrap the default exception handler and capture all exceptions passed to it.
+     * This allows us to assert on the exceptions in the tests
+     */
+    static class CapturingExceptionHandler implements ExceptionHandler {
+        private final ExceptionHandler delegateExceptionHandler = ConsentRequestAccessAuthorisationFilter.createDefaultExceptionHandler();
+
+        private final List<Exception> capturedExceptions = new CopyOnWriteArrayList<>();
+
+        @Override
+        public Response onException(Context context, Exception ex) {
+            capturedExceptions.add(ex);
+            return delegateExceptionHandler.onException(context, ex);
+        }
+    }
+
+    private void verifyExceptionHandlerContainsSingleException(Class<?> expectedExceptionClass, String expectedExceptionMessage) {
+        assertEquals(1, exceptionHandler.capturedExceptions.size());
+        final Exception exception = exceptionHandler.capturedExceptions.get(0);
+        assertEquals(expectedExceptionClass, exception.getClass());
+        assertEquals(expectedExceptionMessage, exception.getMessage());
+    }
+
+    private static void verifyInternalServerErrorResponse(Promise<Response, NeverThrowsException> responsePromise) {
+        try {
+            final Response response = responsePromise.get(1, TimeUnit.MILLISECONDS);
+            assertEquals(Status.INTERNAL_SERVER_ERROR.getCode(), response.getStatus().getCode());
+        } catch (ExecutionException | TimeoutException | InterruptedException e) {
+            throw new RuntimeException("Unexpected exception occurred getting response", e);
+        }
+    }
+
+    private static void verifyUnauthorisedResponse(Promise<Response, NeverThrowsException> responsePromise) {
+        try {
+            final Response response = responsePromise.get(1, TimeUnit.MILLISECONDS);
+            assertEquals(Status.UNAUTHORIZED.getCode(), response.getStatus().getCode());
+        } catch (ExecutionException | TimeoutException | InterruptedException e) {
+            throw new RuntimeException("Unexpected exception occurred getting response", e);
+        }
+    }
+
+    private static void verifySuccessResponse(Promise<Response, NeverThrowsException> responsePromise, TestSuccessResponseHandler responseHandler) {
+        try {
+            final Response response = responsePromise.get(1, TimeUnit.MILLISECONDS);
+            assertEquals(Status.OK.getCode(), response.getStatus().getCode());
+            assertEquals(1, responseHandler.getNumInteractions());
+        } catch (ExecutionException | TimeoutException | InterruptedException e) {
+            throw new RuntimeException("Unexpected exception occurred getting response", e);
+        }
+    }
+
+    private static SsoTokenContext createSsoTokenContext(Context parent, String uid) {
+        // SessionInfo.username is mapped to SsoTokenContext.info.uid
+        final JsonValue rawSessionInfo = json(object(field("username", uid)));
+        final SessionInfo sessionInfo = new SessionInfo("dummyToken", rawSessionInfo);
+        return SsoTokenContext.fromSessionInfo(parent, sessionInfo, "loginEndpoint");
+    }
+
+    private static JwtValidationContext createMockJwtValidationContext(String username) {
+        final JwtValidationContext jwtValidationContext = mock(JwtValidationContext.class);
+        final JwtClaimsSet claims = new JwtClaimsSet(username != null ? Map.of("username", username) : Map.of());
+        when(jwtValidationContext.getClaims()).thenReturn(claims);
+        return jwtValidationContext;
+    }
+
+    @Test
+    void testAuthorisedUser() {
+        final TestSuccessResponseHandler responseHandler = new TestSuccessResponseHandler();
+        final Context context = createSsoTokenContext(createMockJwtValidationContext(TEST_USER_ID), TEST_USER_ID);
+        verifySuccessResponse(filter.filter(context, new Request(), responseHandler), responseHandler);
+    }
+
+    @Test
+    void testUnauthorisedUser() {
+        final TestSuccessResponseHandler responseHandler = new TestSuccessResponseHandler();
+        final Context context = createSsoTokenContext(createMockJwtValidationContext("SomeOtherUser"), TEST_USER_ID);
+        verifyUnauthorisedResponse(filter.filter(context, new Request(), responseHandler));
+    }
+
+    @Test
+    void testSsoTokenContextMissing() {
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(createMockJwtValidationContext(TEST_USER_ID),
+                new Request(), new TestSuccessResponseHandler());
+
+        verifyInternalServerErrorResponse(responsePromise);
+        verifyExceptionHandlerContainsSingleException(IllegalArgumentException.class,
+                "No context of type org.forgerock.openig.openam.SsoTokenContext found.");
+    }
+
+    @Test
+    void testJwtValidationContextMissing() {
+        final RootContext rootContext = new RootContext("root");
+        final SsoTokenContext ssoTokenContext = createSsoTokenContext(rootContext, "test-user");
+
+        verifyInternalServerErrorResponse(filter.filter(ssoTokenContext, new Request(), new TestSuccessResponseHandler()));
+        verifyExceptionHandlerContainsSingleException(IllegalArgumentException.class,
+                "No context of type org.forgerock.openig.filter.jwt.JwtValidationContext found.");
+    }
+
+    @Test
+    void testJwtValidationContextUsernameClaimMissing() {
+        final TestSuccessResponseHandler responseHandler = new TestSuccessResponseHandler();
+        final Context context = createSsoTokenContext(createMockJwtValidationContext(null), TEST_USER_ID);
+        verifyInternalServerErrorResponse(filter.filter(context, new Request(), responseHandler));
+        verifyExceptionHandlerContainsSingleException(IllegalStateException.class,
+                "consent_request JWT username claim is missing or not a string");
+    }
+
+    @Test
+    void testSsoTokenContextUidClaimMissing() {
+        final TestSuccessResponseHandler responseHandler = new TestSuccessResponseHandler();
+        final Context context = createSsoTokenContext(createMockJwtValidationContext(TEST_USER_ID), null);
+        verifyInternalServerErrorResponse(filter.filter(context, new Request(), responseHandler));
+        verifyExceptionHandlerContainsSingleException(IllegalStateException.class,
+                "SsoTokenContext.uid is missing or not a string");
+    }
+
+    @Test
+    void testFilterCreatedByHeaplet() throws Exception {
+        final Heaplet heaplet = new Heaplet();
+        final ConsentRequestAccessAuthorisationFilter filterCreatedByHeaplet =
+                (ConsentRequestAccessAuthorisationFilter) heaplet.create(Name.of("heaplet"),
+                        json(object()), new HeapImpl(Name.of("heap")));
+
+        final TestSuccessResponseHandler responseHandler = new TestSuccessResponseHandler();
+        final Context context = createSsoTokenContext(createMockJwtValidationContext(TEST_USER_ID), TEST_USER_ID);
+        verifySuccessResponse(filterCreatedByHeaplet.filter(context, new Request(), responseHandler), responseHandler);
+    }
+}


### PR DESCRIPTION
Adding routes which protect access to the RCS-UI. 

Route: 81-rcs-ui.json protects the call to the rcs-ui /consent endpoint and does authentication + authorisation checks.

Route: 82-rcs-ui-assets.json protects calls to the rcs-ui scripts and assets, it only authentication checks. Capturing is also turned off on this route to avoid spamming the logs with javascript/css files.

Utilising IdTokenValidationFilter to validate the consent_request JWT, this filter verifies the signature and validates the "exp", "iat", "iss" and "aud" claims.

The ConsentRequestAccessAuthorisationFilter uses the SsoTokenContext and JwtValidationContext set by the SingleSignOnFilter and IdTokenValidationFilter respectively. Using these contexts, the filter verifies that the userId of the SSOToken matches that of the consent_request JWT signed by AM, if these match then the filter allows the request to continue along the chain, otherwise a HTTP 401 is returned.

https://github.com/SecureApiGateway/SecureApiGateway/issues/793