### PR TITLE
805: Adding route 83-rcs-api.json which protects the RCS API

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/83-rcs-api.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/83-rcs-api.json
@@ -1,0 +1,70 @@
+{
+  "comment": "PSU access to RCS API (called from the UI via the browser), ensures that the PSU is authorized to access the consent",
+  "name": "83 - RCS API Access",
+  "auditService": "AuditService-OB-Route",
+  "condition": "${matches(request.uri.path, '^/rcs/api/')}",
+  "baseURI": "http://&{rcs.api.internal.svc}:8080",
+  "capture": [
+    "response",
+    "request"
+  ],
+  "handler": {
+    "type": "Chain",
+    "config": {
+      "filters": [
+        "SBATFapiInteractionFilterChain",
+        {
+          "name": "SingleSignOnFilter",
+          "type": "SingleSignOnFilter",
+          "config": {
+            "amService": "AmService-OBIE"
+          }
+        },
+        {
+          "name": "RcsApiConsentRequestJwtResolver",
+          "type": "ScriptableFilter",
+          "comment": "Resolves the location of the consent request JWT and adds it to the attributes context for ConsentRequestJwtValidationFilter to validate",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "RcsApiConsentRequestJwtResolver.groovy"
+          }
+        },
+        {
+          "name": "ConsentRequestJwtValidationFilter",
+          "type": "IdTokenValidationFilter",
+          "comment": "IdTokenValidationFilter is an extension of JwtValidationFilter which, in addition to signature validation, validates the following claims: aud, iss, exp, iat",
+          "config": {
+            "idToken": "${attributes.consentRequestJwt}",
+            "verificationSecretId": "any.value.in.regex.format",
+            "secretsProvider": "SecretsProvider-AmJWK",
+            "issuer": "https://&{ig.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+            "audience": "&{rcs.consent.response.jwt.issuer}"
+          }
+        },
+        {
+          "name": "ConsentRequestAccessAuthorisationFilter",
+          "type": "ConsentRequestAccessAuthorisationFilter"
+        },
+        {
+          "comment": "Add host header for downstream resource server",
+          "name": "HeaderFilter-RemoveHeaders",
+          "type": "HeaderFilter",
+          "config": {
+            "messageType": "REQUEST",
+            "remove": [
+              "host",
+              "X-Forwarded-Host",
+              "X-Scheme",
+              "X-Forwarded-Scheme",
+              "X-Forwarded-Proto",
+              "upgrade-insecure-requests",
+              "ssl-client-verify",
+              "referer"
+            ]
+          }
+        }
+      ],
+      "handler": "RcsReverseProxyHandler"
+    }
+  }
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/RcsApiConsentRequestJwtResolver.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/RcsApiConsentRequestJwtResolver.groovy
@@ -1,0 +1,31 @@
+/**
+ * Script which resolves the location of the Consent Request JWT for calls to the RCS Backend (API)
+ *
+ * There are currently 2 backend API calls:
+ * - /details which populates the UI, in this call the POST body contains the jwt as a raw string
+ * - /decision which submits the consent decision, in this call the POST body contains a json object with the jwt in the "consentJwt" field
+ */
+
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id")
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
+SCRIPT_NAME = "[RcsApiConsentRequestJwtResolver] (" + fapiInteractionId + ") - "
+logger.debug(SCRIPT_NAME + "Running...")
+
+def requestPath = contexts.router.remainingUri
+if (requestPath.endsWith("/")) {
+    requestPath = requestPath.substring(0, requestPath.length() - 1)
+}
+def consentJwt
+if (requestPath.endsWith("/details")) {
+    consentJwt = request.entity.getString()
+} else if (requestPath.endsWith("/decision")) {
+    consentJwt = request.entity.getJson().consentJwt
+} else {
+    logger.error(SCRIPT_NAME + " unsupported RCS backend uri: " + requestPath)
+    return new Response(Status.BAD_REQUEST)
+}
+
+// Add the jwt to the attributes context so that it can be used by other filters
+attributes.consentRequestJwt = consentJwt
+
+next.handle(context, request)


### PR DESCRIPTION
The new route does authentication and authorisation checks on calls made to the RCS API. These changes are similar to those made for the RCS UI in PR: https://github.com/SecureApiGateway/securebanking-openbanking-uk-gateway/pull/301

A new filter has been added to the route: RcsApiConsentRequestJwtResolver which resolves the consent_request JWT for the ConsentRequestJwtValidationFilter to validate it. The JWT is found in different locations depending on which API call is being made.

To do the authorisation checks we are validating the consent_request JWT. This means the RCS backend can trust that the JWT has had its signature verified.

https://github.com/SecureApiGateway/SecureApiGateway/issues/805